### PR TITLE
ESLintの除外フォルダ設定を追加

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -5,6 +5,9 @@ import pluginReact from "eslint-plugin-react";
 
 /** @type {import('eslint').Linter.Config[]} */
 export default [
+  {
+    ignores: ["dist/", "src-tauri/"],
+  },
   { files: ["**/*.{js,mjs,cjs,ts,jsx,tsx}"] },
   { languageOptions: { globals: globals.browser } },
   pluginJs.configs.recommended,


### PR DESCRIPTION
## 概要

ESLint の設定において lint の対象外として Tauri で使用/作成されるフォルダを追加する。

対象は以下のフォルダで、この中身は lint の対象とする必要がないため。

- `dist/` : Tauri の生成物が格納されるフォルダ
- `src-tauri/` : Tauri の Rust 側のコードが格納されるフォルダで、一部 JS ファイルが存在する

