### PR TITLE
eslint-plugin-react-hooksを導入

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -2,6 +2,7 @@ import globals from "globals";
 import pluginJs from "@eslint/js";
 import tseslint from "typescript-eslint";
 import pluginReact from "eslint-plugin-react";
+import reactHooks from "eslint-plugin-react-hooks";
 
 /** @type {import('eslint').Linter.Config[]} */
 export default [
@@ -14,9 +15,11 @@ export default [
   ...tseslint.configs.recommended,
   pluginReact.configs.flat.recommended,
   {
+    plugins: { "react-hooks": reactHooks },
     rules: {
       "react/react-in-jsx-scope": "off",
       "react/jsx-uses-react": "off",
+      ...reactHooks.configs.recommended.rules,
     },
   },
 ];

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@vitejs/plugin-react": "^4.3.4",
     "eslint": "^9.20.1",
     "eslint-plugin-react": "^7.37.4",
+    "eslint-plugin-react-hooks": "^5.1.0",
     "globals": "^15.15.0",
     "typescript": "~5.6.2",
     "typescript-eslint": "^8.24.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,6 +42,9 @@ importers:
       eslint-plugin-react:
         specifier: ^7.37.4
         version: 7.37.4(eslint@9.20.1)
+      eslint-plugin-react-hooks:
+        specifier: ^5.1.0
+        version: 5.1.0(eslint@9.20.1)
       globals:
         specifier: ^15.15.0
         version: 15.15.0
@@ -830,6 +833,12 @@ packages:
   escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
+
+  eslint-plugin-react-hooks@5.1.0:
+    resolution: {integrity: sha512-mpJRtPgHN2tNAvZ35AMfqeB3Xqeo273QxrHJsbBEPWODRM4r0yB6jfoROqKEYrOn27UtRPpcpHc2UqyBSuUNTw==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0
 
   eslint-plugin-react@7.37.4:
     resolution: {integrity: sha512-BGP0jRmfYyvOyvMoRX/uoUeW+GqNj9y16bPQzqAHf3AYII/tDs+jMN0dBVkl88/OZwNGwrVFxE7riHsXVfy/LQ==}
@@ -2400,6 +2409,10 @@ snapshots:
   escalade@3.2.0: {}
 
   escape-string-regexp@4.0.0: {}
+
+  eslint-plugin-react-hooks@5.1.0(eslint@9.20.1):
+    dependencies:
+      eslint: 9.20.1
 
   eslint-plugin-react@7.37.4(eslint@9.20.1):
     dependencies:


### PR DESCRIPTION

## 概要

フックに対する lint を行うため、eslint-plugin-react-hooks を導入する。

```sh
pnpm add -D eslint-plugin-react-hooks
```

このコマンドを実行後、設定ファイルに追記して有効化する。

## 備考

eslint-plugin-react-hooks には型定義ファイルがないため以下の警告が出るが、現状では無視しておくしかない。

> モジュール 'eslint-plugin-react-hooks' の宣言ファイルが見つかりませんでした。'/Volumes/Nina/Code/Tauri/magv/node_modules/.pnpm/eslint-plugin-react-hooks@5.1.0_eslint@9.20.1/node_modules/eslint-plugin-react-hooks/index.js' は暗黙的に 'any' 型になります。
>   存在する場合は `npm i --save-dev @types/eslint-plugin-react-hooks` を試すか、`declare module 'eslint-plugin-react-hooks';` を含む新しい宣言 (.d.ts) ファイルを追加しますts(7016)
