### PR TITLE
Zip ファイルの先頭の画像を表示するテスト実装

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@tailwindcss/vite": "^4.0.6",
     "@tauri-apps/api": "^2",
     "@tauri-apps/plugin-opener": "^2",
+    "fflate": "^0.8.2",
     "jotai": "^2.12.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       '@tauri-apps/plugin-opener':
         specifier: ^2
         version: 2.2.5
+      fflate:
+        specifier: ^0.8.2
+        version: 0.8.2
       jotai:
         specifier: ^2.12.0
         version: 2.12.0(@types/react@18.3.18)(react@18.3.1)
@@ -1111,6 +1114,9 @@ packages:
 
   fastq@1.19.0:
     resolution: {integrity: sha512-7SFSRCNjBQIZH/xZR3iy5iQYR8aGBE0h3VG6/cwlbrpdciNYBMotQav8c1XI3HjHH+NikUpP53nPdlZSdWmFzA==}
+
+  fflate@0.8.2:
+    resolution: {integrity: sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==}
 
   file-entry-cache@8.0.0:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
@@ -3082,6 +3088,8 @@ snapshots:
   fastq@1.19.0:
     dependencies:
       reusify: 1.0.4
+
+  fflate@0.8.2: {}
 
   file-entry-cache@8.0.0:
     dependencies:

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -3,23 +3,25 @@ import { useAtom } from "jotai";
 import { listen } from "@tauri-apps/api/event";
 import {
   openImagePathAtom,
-  openPathAtom,
+  // openPathAtom,
   useKeyboardEvent,
 } from "../states/image";
 import { SingleImageView } from "./SingleImageView";
 import { Log } from "./Log";
+import { openZipAtom } from "../types/zip";
 
 export function App() {
-  const [, openPath] = useAtom(openPathAtom);
+  // const [, openPath] = useAtom(openPathAtom);
+  const [, openZip] = useAtom(openZipAtom);
   const [openImagePath] = useAtom(openImagePathAtom);
   const handleKeyboardEvent = useKeyboardEvent();
 
   // ファイルがドロップされたときの処理
   const handleDrop = useCallback(
     async (path: string) => {
-      openPath(path);
+      openZip(path);
     },
-    [openPath]
+    [openZip]
   );
 
   // キーが押されたときの処理

--- a/src/components/SingleImageView.tsx
+++ b/src/components/SingleImageView.tsx
@@ -18,7 +18,11 @@ export function SingleImageView(props: Props) {
       {props.path ? (
         <img
           className="h-dvh object-contain"
-          src={convertFileSrc(props.path)}
+          src={
+            props.path.startsWith("data:")
+              ? props.path // base64 の場合はそのまま表示
+              : convertFileSrc(props.path)
+          }
         />
       ) : (
         <div className="text-stone-200">

--- a/src/types/zip.ts
+++ b/src/types/zip.ts
@@ -1,0 +1,45 @@
+import { atom } from "jotai";
+import * as fflate from "fflate";
+import { convertFileSrc } from "@tauri-apps/api/core";
+import { openImagePathAtom } from "../states/image";
+
+// const openZipData = atom<Unzipped | undefined>(undefined);
+
+/**
+ * zip ファイルを開く atom
+ */
+export const openZipAtom = atom(null, async (_, set, path: string) => {
+  const response = await fetch(convertFileSrc(path));
+  const arrayBuffer = await response.arrayBuffer();
+  const unzipped = fflate.unzipSync(new Uint8Array(arrayBuffer));
+
+  const fileNames = Object.keys(unzipped)
+    .filter((name) => !name.startsWith("__MACOSX/")) // Mac のリソースファイルを除く
+    .filter((name) => !name.endsWith("/")); // ディレクトリを除く
+
+  // ひとまず最初のファイルを表示する
+  const imageData = unzipped[fileNames[0]];
+  const blob = new Blob([imageData]);
+  const base64 = await base64FromBlob(blob);
+  set(openImagePathAtom, { type: "single", path: base64 });
+});
+
+/**
+ * Blob を Base64 に変換する
+ */
+export const base64FromBlob = async (file: File | Blob): Promise<string> => {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => {
+      if (reader.result instanceof ArrayBuffer || reader.result == null) {
+        reject(new Error("FileReader result is not an string"));
+      } else {
+        resolve(reader.result);
+      }
+    };
+    reader.onerror = (e) => {
+      reject(e);
+    };
+    reader.readAsDataURL(file);
+  });
+};


### PR DESCRIPTION

## 概要

Zip ファイルをドロップしたときの挙動のテストとして、先頭画像のみを表示する暫定実装を行います。

> [!IMPORTANT]
> この PR をマージした時点では、画像ファイルやそのフォルダを開こうとしても開けなくなっています。
> そのうち条件分岐を追加して対応します。

## 詳細

TypeScript で zip ファイルを扱うために [fflate](https://github.com/101arrowz/fflate) を導入してみました。

パフォーマンス的には、「ファイル一覧を取得 → 開く対象画像のみのデータを取得 → 画像表示」が良さそうなのですが、どうやらそれを行える JS/TS のライブラリがないようです。

しがって、**最初にすべてのファイルの解凍まで行う実装**になっています。これは大きなファイルを開いたときに時間がかかりそう（+ かなりメモリを消費しそう）ですが、開発者自身のマシン（M4 Mac mini）では実用的な速度が出ているので良いのかと。

圧縮ファイルの扱いは Rust 側で行った方が速そうなので、そのうち検討するかもしれません。
