### PR TITLE
Blob を画像として直接表示するように変更

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -60,11 +60,11 @@ export function App() {
     <main className="h-dvh">
       {openImagePath && openImagePath?.type === "double" ? (
         <div className="flex justify-center items-center">
-          <SingleImageView path={openImagePath?.path2} />
-          <SingleImageView path={openImagePath?.path1} />
+          <SingleImageView source={openImagePath?.path2} />
+          <SingleImageView source={openImagePath?.path1} />
         </div>
       ) : (
-        <SingleImageView path={openImagePath?.path} />
+        <SingleImageView source={openImagePath?.path} />
       )}
       <Log />
     </main>

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -60,11 +60,11 @@ export function App() {
     <main className="h-dvh">
       {openImagePath && openImagePath?.type === "double" ? (
         <div className="flex justify-center items-center">
-          <SingleImageView source={openImagePath?.path2} />
-          <SingleImageView source={openImagePath?.path1} />
+          <SingleImageView source={openImagePath?.source2} />
+          <SingleImageView source={openImagePath?.source1} />
         </div>
       ) : (
-        <SingleImageView source={openImagePath?.path} />
+        <SingleImageView source={openImagePath?.source} />
       )}
       <Log />
     </main>

--- a/src/components/SingleImageView.tsx
+++ b/src/components/SingleImageView.tsx
@@ -2,9 +2,13 @@ import { convertFileSrc } from "@tauri-apps/api/core";
 
 type Props = {
   /**
-   * 画像のパス
+   * 画像のソース
+   *
+   * - ローカルのパス (string)
+   * - 画像を Base64 エンコードしたもの (string)
+   * - 画像の Blob
    */
-  path?: string;
+  source?: string | Blob;
 };
 
 /**
@@ -12,23 +16,27 @@ type Props = {
  *
  * 画像のローカルなパスを渡すことで表示する
  */
-export function SingleImageView(props: Props) {
-  return (
-    <div className="h-dvh bg-stone900 flex items-center justify-center">
-      {props.path ? (
-        <img
-          className="h-dvh object-contain"
-          src={
-            props.path.startsWith("data:")
-              ? props.path // base64 の場合はそのまま表示
-              : convertFileSrc(props.path)
-          }
-        />
-      ) : (
+export function SingleImageView({ source }: Props) {
+  if (!source) {
+    return (
+      <div className="h-dvh bg-stone900 flex items-center justify-center">
         <div className="text-stone-200">
           画像ファイルまたはフォルダをドロップしてください
         </div>
-      )}
+      </div>
+    );
+  }
+
+  const src =
+    source instanceof Blob
+      ? URL.createObjectURL(source) // Blob は URL を生成
+      : source.startsWith("data:")
+      ? source // Base64 はそのまま
+      : convertFileSrc(source); // ローカルのパスは、表示用のパスに変換
+
+  return (
+    <div className="h-dvh bg-stone900 flex items-center justify-center">
+      {<img className="h-dvh object-contain" src={src} />}
     </div>
   );
 }

--- a/src/states/image.ts
+++ b/src/states/image.ts
@@ -36,13 +36,13 @@ export const openPathAtom = atom(null, async (_, set, path: string) => {
   if (fileList.find((file) => file === path)) {
     // ドロップされたファイルが画像だったときは、そのまま表示する
     // TODO: 縦横判定を行う
-    set(openImagePathAtom, { type: "single", path });
+    set(openImagePathAtom, { type: "single", source: path });
     set(imagePathsAtom, fileList);
   } else {
     // 画像以外がドロップされたときは、当該フォルダの中の先頭の画像を表示する
     // 画像ファイルがない場合は何もしない
     if (fileList.length > 0) {
-      set(openImagePathAtom, { type: "single", path: fileList[0] });
+      set(openImagePathAtom, { type: "single", source: fileList[0] });
       set(imagePathsAtom, fileList);
     }
   }
@@ -77,8 +77,8 @@ const nextImageAtom = atom(null, async (get, set) => {
   // インデックス検索の対象として、1枚表示時は現在表示している画像に、2枚表示時は2枚目の画像にする
   const path =
     currentImagePath?.type === "single"
-      ? currentImagePath?.path
-      : currentImagePath?.path2;
+      ? currentImagePath?.source
+      : currentImagePath?.source2;
 
   const currentIndex = imagePaths.findIndex((p) => p === path);
 
@@ -102,15 +102,15 @@ const nextImageAtom = atom(null, async (get, set) => {
   ) {
     set(openImagePathAtom, {
       type: "single",
-      path: imagePaths[currentIndex + 1],
+      source: imagePaths[currentIndex + 1],
     });
     return;
   }
   // 2枚とも縦長の画像だったときは、2枚表示にする
   set(openImagePathAtom, {
     type: "double",
-    path1: imagePaths[currentIndex + 1],
-    path2: imagePaths[currentIndex + 2],
+    source1: imagePaths[currentIndex + 1],
+    source2: imagePaths[currentIndex + 2],
   });
 });
 
@@ -124,8 +124,8 @@ export const prevImageAtom = atom(null, async (get, set) => {
   // インデックス検索の対象として、1枚表示時は現在表示している画像に、2枚表示時も1枚目の画像にする
   const path =
     currentImagePath?.type === "single"
-      ? currentImagePath?.path
-      : currentImagePath?.path1;
+      ? currentImagePath?.source
+      : currentImagePath?.source1;
   const currentIndex = imagePaths.findIndex((p) => p === path);
 
   // 2つ前の画像までの縦横の向きを取得
@@ -148,14 +148,14 @@ export const prevImageAtom = atom(null, async (get, set) => {
   ) {
     set(openImagePathAtom, {
       type: "single",
-      path: imagePaths[currentIndex - 1],
+      source: imagePaths[currentIndex - 1],
     });
     return;
   }
   // 2枚とも縦長の画像だったときは、2枚表示にする
   set(openImagePathAtom, {
     type: "double",
-    path1: imagePaths[currentIndex - 2], // 2つ前の画像が1枚目
-    path2: imagePaths[currentIndex - 1],
+    source1: imagePaths[currentIndex - 2], // 2つ前の画像が1枚目
+    source2: imagePaths[currentIndex - 1],
   });
 });

--- a/src/types/image.ts
+++ b/src/types/image.ts
@@ -3,7 +3,7 @@
  */
 export type SingleImageMode = {
   type: "single";
-  path: string;
+  source: string | Blob;
 };
 
 /**
@@ -11,8 +11,8 @@ export type SingleImageMode = {
  */
 export type DoubleImageMode = {
   type: "double";
-  path1: string;
-  path2: string;
+  source1: string | Blob;
+  source2: string | Blob;
 };
 
 /**

--- a/src/types/zip.ts
+++ b/src/types/zip.ts
@@ -30,6 +30,13 @@ type ZipData = {
   };
 };
 
+// -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -
+// 内部データ保持 atom
+// -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -
+
+/**
+ * 開いている zip のデータを保持する atom
+ */
 const openZipDataAtom = atom<ZipData | undefined>(undefined);
 
 /**
@@ -41,6 +48,10 @@ const imageNameListAtom = atom<string[]>([]);
  * 開いている画像ファイルのインデックスを保持する atom
  */
 const openImageIndexAtom = atom<number>(0);
+
+// -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -
+// 外部公開 atom
+// -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -
 
 /**
  * zip ファイルを開く atom


### PR DESCRIPTION
## 概要

これまでは zip ファイルを扱う際、画像のソースとして Base64 へ変換した文字列を使用していたが、画像の Blob をそのまま表示するように変更する。

また zip の解凍データも Blob として保持する。これまでは生データと Base64 の両方を保持していたが、Blob のみにすることでメモリ使用量は削減されるのではないかと思われる。
