### PR TITLE
アーカイブファイル内のページ移動系処理のリファクタリング

### DIFF
--- a/src/types/zip.ts
+++ b/src/types/zip.ts
@@ -82,8 +82,6 @@ export const openZipAtom = atom(
     set(updateArchiveListAtom, path);
     set(openArchivePathAtom, path);
 
-    set(openImageIndexAtom, 0);
-
     // アーカイブのファイル名をウィンドウのタイトルに設定
     const zipName = path.split("/").pop();
     if (zipName) {
@@ -105,41 +103,11 @@ export const openZipAtom = atom(
       return acc;
     }, {});
 
-    // 最初のファイルを表示する
-    const name1 = fileNames[0];
-    // 1つも画像ファイルがない場合は何もしない
-    if (!name1) {
-      return;
-    }
-
-    await convertData(bufData, name1);
+    // 初期化したデータを保持
     set(openZipDataAtom, bufData);
 
-    const name2 = fileNames[1];
-    // 1つしかファイルがない場合と1枚目が横長だった場合は、1つだけ表示する
-    if (!name2 || bufData[name1].orientation === "landscape") {
-      set(openImagePathAtom, { type: "single", source: bufData[name1].blob });
-      return;
-    }
-
-    await convertData(bufData, name2);
-    set(openZipDataAtom, bufData);
-
-    // 1枚目と2枚目が両方とも縦長だった場合は2枚表示する
-    if (
-      bufData[name1].orientation === "portrait" &&
-      bufData[name2].orientation === "portrait"
-    ) {
-      set(openImagePathAtom, {
-        type: "double",
-        source1: bufData[name1].blob,
-        source2: bufData[name2].blob,
-      });
-      return;
-    }
-
-    // 1枚目が縦長で2枚目が横長だった場合は1枚目だけ表示する
-    set(openImagePathAtom, { type: "single", source: bufData[name1].blob });
+    // 最初のページを表示
+    set(moveIndexAtom, { index: 0 });
   }
 );
 

--- a/src/types/zip.ts
+++ b/src/types/zip.ts
@@ -437,14 +437,13 @@ const moveFirstImageAtom = atom(null, async (_, set) => {
 /**
  * 最後のページを表示する atom
  *
- * 最後の2枚が縦画像だったら2枚とも表示する
+ * 最後の2枚が縦画像だったら見開き表示する
  */
 const moveLastImageAtom = atom(null, async (get, set) => {
   const imageList = get(imageNameListAtom);
   const zipData = get(openZipDataAtom);
-  const imageData = get(openImagePathAtom);
 
-  if (!zipData || !imageData) {
+  if (!zipData) {
     return;
   }
 
@@ -466,21 +465,12 @@ const moveLastImageAtom = atom(null, async (get, set) => {
     zipData[name1].orientation === "portrait" &&
     zipData[name2].orientation === "portrait"
   ) {
-    set(openImagePathAtom, {
-      type: "double",
-      source1: zipData[name1].blob,
-      source2: zipData[name2].blob,
-    });
-    set(openImageIndexAtom, lastIndex - 1);
+    set(moveIndexAtom, { index: lastIndex - 1 });
     return;
   }
 
-  // 2枚目(最後の画像)が横長のとき、または2枚目が縦長で1枚目が横長のときは、2枚目のみを表示する
-  set(openImagePathAtom, {
-    type: "single",
-    source: zipData[name1].blob,
-  });
-  set(openImageIndexAtom, lastIndex);
+  // その他のときは最後の画像のみを表示する
+  set(moveIndexAtom, { index: lastIndex });
 });
 
 // -    -    -    -    -    -    -    -    -    -    -    -    -    -    -    -    -

--- a/src/types/zip.ts
+++ b/src/types/zip.ts
@@ -357,9 +357,8 @@ const movePrevSingleImageAtom = atom(null, async (get, set) => {
   const imageList = get(imageNameListAtom);
   const index = get(openImageIndexAtom);
   const zipData = get(openZipDataAtom);
-  const imageData = get(openImagePathAtom);
 
-  if (!zipData || !imageData) {
+  if (!zipData) {
     return;
   }
 
@@ -373,58 +372,21 @@ const movePrevSingleImageAtom = atom(null, async (get, set) => {
 
   await convertData(zipData, name0);
   await convertData(zipData, name1);
-  set(openZipDataAtom, zipData);
-
-  // 現在が縦画像を表示しているとき
-  if (zipData[name0].orientation === "portrait") {
-    // -1枚目が縦のときは、0枚目と-1枚目を表示する
-    if (zipData[name1].orientation === "portrait") {
-      set(openImagePathAtom, {
-        type: "double",
-        source1: zipData[name1].blob,
-        source2: zipData[name0].blob,
-      });
-      set(openImageIndexAtom, index - 1);
-      return;
-    } else {
-      // -1枚目が横のときは、-1枚目のみを表示する
-      set(openImagePathAtom, {
-        type: "single",
-        source: zipData[name1].blob,
-      });
-      set(openImageIndexAtom, index - 1);
-      return;
-    }
-  }
-
   await convertData(zipData, name2);
   set(openZipDataAtom, zipData);
 
-  // 現在が横画像を表示しているとき
-
-  // -1枚目と-2枚目が両方とも縦長のときは、2枚とも表示する
+  // 現在、横画像を表示していて、-1枚目と-2枚目が両方とも縦長のときは、2枚戻って見開き表示する
   if (
+    zipData[name0].orientation === "landscape" &&
+    name2 &&
     zipData[name1].orientation === "portrait" &&
     zipData[name2].orientation === "portrait"
   ) {
-    set(openImagePathAtom, {
-      type: "double",
-      source1: zipData[name2].blob,
-      source2: zipData[name1].blob,
-    });
-    set(openImageIndexAtom, index - 2);
-    return;
+    set(moveIndexAtom, { index: index - 2 });
   }
 
-  // それ以外のときは、-1枚目のみを表示する
-  if (zipData[name1].orientation === "landscape") {
-    set(openImagePathAtom, {
-      type: "single",
-      source: zipData[name1].blob,
-    });
-    set(openImageIndexAtom, index - 1);
-    return;
-  }
+  // それ以外のときは、-1枚目のみを基準に表示する (見開き判定は表示処理で実施)
+  set(moveIndexAtom, { index: index - 1 });
 });
 
 /**

--- a/src/types/zip.ts
+++ b/src/types/zip.ts
@@ -161,9 +161,6 @@ export const handleMouseWheelEventAtom = atom(
 
 /**
  * 指定したインデックスのページへ移動する atom
- *
- * @param index 開くインデックス
- * @param isForceSingle 強制的に1枚表示にするかどうかのフラグ
  */
 const moveIndexAtom = atom(
   null,
@@ -172,10 +169,12 @@ const moveIndexAtom = atom(
     set,
     {
       index,
-      isForceSingle = false,
+      forceSingle = false,
     }: {
+      /** 開くインデックス */
       index: number;
-      isForceSingle?: boolean;
+      /** 強制的に1枚表示にするかどうかのフラグ */
+      forceSingle?: boolean;
     }
   ) => {
     const imageList = get(imageNameListAtom);
@@ -196,7 +195,7 @@ const moveIndexAtom = atom(
     set(openImageIndexAtom, index);
 
     // 強制的に1枚のみを表示する
-    if (isForceSingle) {
+    if (forceSingle) {
       await convertData(zipData, name1);
       set(openZipDataAtom, zipData);
       set(openImagePathAtom, {
@@ -310,7 +309,7 @@ const prevImageAtom = atom(null, async (get, set) => {
     (name2 && zipData[name2].orientation === "landscape")
   ) {
     // 最初の画像が 縦縦 と並んでいるときに見開き表示とならないよう、1枚表示を強制
-    set(moveIndexAtom, { index: index - 1, isForceSingle: true });
+    set(moveIndexAtom, { index: index - 1, forceSingle: true });
     return;
   }
 

--- a/src/types/zip.ts
+++ b/src/types/zip.ts
@@ -345,64 +345,23 @@ const prevImageAtom = atom(null, async (get, set) => {
 });
 
 /**
- * 1枚だけ次の画像（ページ）に移動する atom
+ * 1枚だけ次の画像に移動する atom
  */
 const moveNextSingleImageAtom = atom(null, async (get, set) => {
   const imageList = get(imageNameListAtom);
   const index = get(openImageIndexAtom);
-  const zipData = get(openZipDataAtom);
-  const imageData = get(openImagePathAtom);
+  const imageProperty = get(openImagePathAtom);
 
-  if (!zipData || !imageData) {
+  if (!imageProperty) {
     return;
   }
 
-  const name1 = imageList[index + 1];
-  const name2 = imageList[index + 2];
-
-  if (!name1) {
+  // 最後のページとして2枚表示されている場合は移動せず見開きのままとする
+  if (imageProperty.type === "double" && imageList.length - 2 <= index) {
     return;
   }
 
-  // +1枚目のデータを埋める
-  await convertData(zipData, name1);
-  set(openZipDataAtom, zipData);
-
-  // +1枚目が横長のときと、+2枚目がないときは、+1枚目のみを表示する
-  // 「+1枚目が縦長ではない」という条件で、何らかの原因で縦横を取得できなかった場合に念の為対応している
-  if (zipData[name1].orientation !== "portrait" || !name2) {
-    set(openImagePathAtom, {
-      type: "single",
-      source: zipData[name1].blob,
-    });
-    set(openImageIndexAtom, index + 1);
-    return;
-  }
-
-  // +2枚目のデータを埋める
-  await convertData(zipData, name2);
-  set(openZipDataAtom, zipData);
-
-  // +1枚目と+2枚目が両方とも縦長のときは、2枚とも表示する
-  if (
-    zipData[name1].orientation === "portrait" &&
-    zipData[name2].orientation === "portrait"
-  ) {
-    set(openImagePathAtom, {
-      type: "double",
-      source1: zipData[name1].blob,
-      source2: zipData[name2].blob,
-    });
-    set(openImageIndexAtom, index + 1);
-    return;
-  }
-
-  // +1枚目が縦長で+2枚目が横長のときは、+1枚目のみを表示する
-  set(openImagePathAtom, {
-    type: "single",
-    source: zipData[name1].blob,
-  });
-  set(openImageIndexAtom, index + 1);
+  set(moveIndexAtom, { index: index + 1 });
 });
 
 /**

--- a/src/types/zip.ts
+++ b/src/types/zip.ts
@@ -631,8 +631,8 @@ const openPrevArchiveAtom = atom(null, async (get, set) => {
  *
  * 基本的に、この関数を呼び出したときは await して終了を待つ必要がある
  */
-async function convertData(target: ZipData, fileName: string) {
-  if (!target[fileName].orientation) {
+async function convertData(target: ZipData, fileName: string | undefined) {
+  if (fileName && !target[fileName].orientation) {
     const base64 = await base64FromBlob(target[fileName].blob);
     target[fileName].orientation = await getImageOrientation(base64);
   }

--- a/src/types/zip.ts
+++ b/src/types/zip.ts
@@ -206,6 +206,7 @@ const moveIndexAtom = atom(
     }
 
     await convertData(zipData, name1);
+    await convertData(zipData, name2);
     set(openZipDataAtom, zipData);
 
     // 1枚目が横長のときと、2枚目がないときは、1枚目のみを表示する
@@ -216,10 +217,6 @@ const moveIndexAtom = atom(
       });
       return;
     }
-
-    // 2枚目のデータを埋める
-    await convertData(zipData, name2);
-    set(openZipDataAtom, zipData);
 
     // 1枚目と2枚目が両方とも縦長のときは、2枚とも表示する
     if (

--- a/src/types/zip.ts
+++ b/src/types/zip.ts
@@ -250,69 +250,17 @@ const moveIndexAtom = atom(
  * 縦画像が1枚だけ表示されるケースもあり得る
  */
 const nextImageAtom = atom(null, async (get, set) => {
-  const imageList = get(imageNameListAtom);
   const openIndex = get(openImageIndexAtom);
-  const zipData = get(openZipDataAtom);
   const imageData = get(openImagePathAtom);
 
-  if (!zipData || !imageData) {
+  if (!imageData) {
     return;
   }
 
-  // 基準のインデックスとして、1枚表示時は現在表示している画像に、2枚表示時は2枚目の画像にする
-  const index = imageData.type === "single" ? openIndex : openIndex + 1;
+  // 現在の表示枚数を元に、次のインデックスを計算する
+  const index = imageData.type === "single" ? openIndex + 1 : openIndex + 2;
 
-  // 次の画像が存在しない場合は何もしない
-  if (imageList.length <= index) {
-    return;
-  }
-
-  const name1 = imageList[index + 1];
-  const name2 = imageList[index + 2];
-
-  if (!name1) {
-    return;
-  }
-
-  // +1枚目のデータを埋める
-  await convertData(zipData, name1);
-  set(openZipDataAtom, zipData);
-
-  // +1枚目が横長のときと、+2枚目がないときは、+1枚目のみを表示する
-  // 「+1枚目が縦長ではない」という条件で、何らかの原因で縦横を取得できなかった場合に念の為対応している
-  if (zipData[name1].orientation !== "portrait" || !name2) {
-    set(openImagePathAtom, {
-      type: "single",
-      source: zipData[name1].blob,
-    });
-    set(openImageIndexAtom, index + 1);
-    return;
-  }
-
-  // +2枚目のデータを埋める
-  await convertData(zipData, name2);
-  set(openZipDataAtom, zipData);
-
-  // +1枚目と+2枚目が両方とも縦長のときは、2枚とも表示する
-  if (
-    zipData[name1].orientation === "portrait" &&
-    zipData[name2].orientation === "portrait"
-  ) {
-    set(openImagePathAtom, {
-      type: "double",
-      source1: zipData[name1].blob,
-      source2: zipData[name2].blob,
-    });
-    set(openImageIndexAtom, index + 1); // 上で計算のためにすでに +1 しているため +1 のみ
-    return;
-  }
-
-  // +1枚目が縦長で+2枚目が横長のときは、+1枚目のみを表示する
-  set(openImagePathAtom, {
-    type: "single",
-    source: zipData[name1].blob,
-  });
-  set(openImageIndexAtom, index + 1);
+  set(moveIndexAtom, { index });
 });
 
 /**

--- a/src/types/zip.ts
+++ b/src/types/zip.ts
@@ -430,61 +430,8 @@ const movePrevSingleImageAtom = atom(null, async (get, set) => {
 /**
  * 最初のページを表示する atom
  */
-const moveFirstImageAtom = atom(null, async (get, set) => {
-  const imageList = get(imageNameListAtom);
-  const zipData = get(openZipDataAtom);
-  const imageData = get(openImagePathAtom);
-
-  if (!zipData || !imageData) {
-    return;
-  }
-
-  const name1 = imageList[0];
-  const name2 = imageList[1];
-
-  if (!name1) {
-    return;
-  }
-
-  // 1枚目のデータを埋める
-  await convertData(zipData, name1);
-  set(openZipDataAtom, zipData);
-
-  // 1枚目が横長のときと、2枚目がないときは、1枚目のみを表示する
-  // 「+1枚目が縦長ではない」という条件で、何らかの原因で縦横を取得できなかった場合に念の為対応している
-  if (zipData[name1].orientation !== "portrait" || !name2) {
-    set(openImagePathAtom, {
-      type: "single",
-      source: zipData[name1].blob,
-    });
-    set(openImageIndexAtom, 1);
-    return;
-  }
-
-  // +2枚目のデータを埋める
-  await convertData(zipData, name2);
-  set(openZipDataAtom, zipData);
-
-  // +1枚目と+2枚目が両方とも縦長のときは、2枚とも表示する
-  if (
-    zipData[name1].orientation === "portrait" &&
-    zipData[name2].orientation === "portrait"
-  ) {
-    set(openImagePathAtom, {
-      type: "double",
-      source1: zipData[name1].blob,
-      source2: zipData[name2].blob,
-    });
-    set(openImageIndexAtom, 1);
-    return;
-  }
-
-  // +1枚目が縦長で+2枚目が横長のときは、+1枚目のみを表示する
-  set(openImagePathAtom, {
-    type: "single",
-    source: zipData[name1].blob,
-  });
-  set(openImageIndexAtom, 1);
+const moveFirstImageAtom = atom(null, async (_, set) => {
+  set(moveIndexAtom, { index: 0 });
 });
 
 /**


### PR DESCRIPTION
## 概要

アーカイブファイル内のページ移動系処理において、指定したインデックスへ移動する1つの関数を使用するようにリファクタリングする。

これまでは各イベントを処理する関数内で、次に表示する画像を判定してから表示処理を行っていた。

しかしページ移動系の処理を一式書いてみたところ、統一して動作するために必要な条件が以下のように判明した。

- ほとんどのケースにおいて、表示するインデックスが分かれば、表示が可能。
  - 見開き表示の判定も、次の画像の縦横が分かれば判別可能。
- ただし、ごく一部の移動において、縦画像が2枚並んでも見開き表示したくないケースがある。

したがってこれに対応した関数を作成し、それを使用して処理を1箇所にまとめるリファクタリングを行う。
