### PR TITLE
インジケーターを組み込んだレイアウトへ変更

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -10,6 +10,7 @@ import {
 } from "../types/zip";
 import { useRestoreConfig, useWindowEvent } from "../hooks/config";
 import { ImageView } from "./ImageView";
+import { Indicator } from "./Indicator";
 
 export function App() {
   // const [, openPath] = useAtom(openPathAtom);
@@ -87,8 +88,9 @@ export function App() {
   }, [handleKeyDown, handleKeyEvent, handleWheelEvent]);
 
   return (
-    <main className="h-dvh">
+    <main className="h-dvh grid grid-rows-[1fr_32px]">
       <ImageView />
+      <Indicator index={3} last={10} />
       <Log />
     </main>
   );

--- a/src/components/ImageView.tsx
+++ b/src/components/ImageView.tsx
@@ -11,12 +11,14 @@ export function ImageView() {
   return (
     <>
       {openImagePath && openImagePath?.type === "double" ? (
-        <div className="flex flex-row-reverse justify-center items-center">
+        <div className="h-[calc(100dvh-32px)] flex flex-row-reverse justify-center items-center">
           <SingleImageView source={openImagePath?.source1} />
           <SingleImageView source={openImagePath?.source2} />
         </div>
       ) : (
-        <SingleImageView source={openImagePath?.source} />
+        <div className="h-[calc(100dvh-32px)]">
+          <SingleImageView source={openImagePath?.source} />
+        </div>
       )}
     </>
   );

--- a/src/components/Indicator.tsx
+++ b/src/components/Indicator.tsx
@@ -1,0 +1,24 @@
+type Props = {
+  /**
+   * 現在開いているページのインデックス
+   */
+  index: number;
+  /**
+   * 最後のページのインデックス
+   */
+  last: number;
+  /**
+   * インジケーターの方向
+   *
+   * - "left": 左に進む（右開き） default
+   * - "right": 右に進む（左開き）
+   */
+  direction?: "left" | "right";
+};
+
+/**
+ * 画像のページ位置を表示するインジケーターコンポーネント
+ */
+export function Indicator({ index, last, direction = "left" }: Props) {
+  return <div className="w-dvw bg-amber-700 h-8"></div>;
+}

--- a/src/components/Indicator.tsx
+++ b/src/components/Indicator.tsx
@@ -20,5 +20,14 @@ type Props = {
  * 画像のページ位置を表示するインジケーターコンポーネント
  */
 export function Indicator({ index, last, direction = "left" }: Props) {
-  return <div className="w-dvw bg-amber-700 h-8"></div>;
+  const percent = last === 0 ? 0 : (index / last) * 100;
+  const rl = direction === "left" ? "right" : "left";
+
+  return (
+    <div className="w-dvw bg-transparent h-8 cursor-pointer relative">
+      {/* <div
+        className={`absolute top-0 ${rl}-0 bg-amber-700 w-[${percent}%] h-8`}
+      ></div> */}
+    </div>
+  );
 }

--- a/src/components/SingleImageView.tsx
+++ b/src/components/SingleImageView.tsx
@@ -19,10 +19,8 @@ type Props = {
 export function SingleImageView({ source }: Props) {
   if (!source) {
     return (
-      <div className="h-dvh bg-stone900 flex items-center justify-center select-none">
-        <div className="text-stone-200">
-          画像ファイルまたはフォルダをドロップしてください
-        </div>
+      <div className="h-full bg-stone900 flex items-center justify-center select-none text-stone-200">
+        画像ファイルまたはフォルダをドロップしてください
       </div>
     );
   }
@@ -35,8 +33,8 @@ export function SingleImageView({ source }: Props) {
       : convertFileSrc(source); // ローカルのパスは、表示用のパスに変換
 
   return (
-    <div className="h-dvh bg-stone900 flex items-center justify-center select-none">
-      {<img className="h-dvh object-contain" src={src} />}
+    <div className="h-full bg-stone900 flex items-center justify-center select-none">
+      {<img className="h-full object-contain" src={src} />}
     </div>
   );
 }


### PR DESCRIPTION
## 概要

画面下部にページの進捗を表すインジケーターを組み込むため、全体的な配置とスタイルを変更する。

CSS Grid によるレイアウトを行うとともに、表示が破綻しないように高さの指定方法の変更等を行う。

インジケーターを途中まで実装したところ、Tailwind CSS では動的なスタイル適用（例えば幅を変えたり）ができないことに気付いたため、現時点ではここでひとまず終わりとして、インジケーターの最終的な実装は後ほど行う。
