### PR TITLE
画像を開いていないときの空メッセージを変更

### DIFF
--- a/src/components/ImageView.tsx
+++ b/src/components/ImageView.tsx
@@ -53,7 +53,7 @@ const PLACEHOLDER_STYLE: React.CSSProperties = {
   userSelect: "none",
   "-webkit-user-select": "none",
   background: "var(--black-color)",
-  color: "var(--white-color)",
+  color: "color-mix(in srgb, var(--white-color) 50%, transparent)",
 };
 
 /**

--- a/src/components/ImageView.tsx
+++ b/src/components/ImageView.tsx
@@ -23,18 +23,53 @@ export function ImageView() {
     overflow: "hidden",
   };
 
+  if (openImagePath && openImagePath?.type === "double") {
+    return (
+      <div style={doubleStyle}>
+        <SingleImageView source={openImagePath?.source1} isHalf justify="left" />
+        <SingleImageView source={openImagePath?.source2} isHalf justify="right" />
+      </div>
+    );
+  }
+
+  if (!openImagePath?.source) {
+    return <EmptyMessage />;
+  }
+
   return (
-    <>
-      {openImagePath && openImagePath?.type === "double" ? (
-        <div style={doubleStyle}>
-          <SingleImageView source={openImagePath?.source1} isHalf justify="left" />
-          <SingleImageView source={openImagePath?.source2} isHalf justify="right" />
-        </div>
-      ) : (
-        <div style={singleStyle}>
-          <SingleImageView source={openImagePath?.source} />
-        </div>
-      )}
-    </>
+    <div style={singleStyle}>
+      <SingleImageView source={openImagePath?.source} />
+    </div>
+  );
+}
+
+/** 空のメッセージのスタイル */
+const PLACEHOLDER_STYLE: React.CSSProperties = {
+  height: "100%",
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+  textAlign: "center",
+  userSelect: "none",
+  "-webkit-user-select": "none",
+  background: "var(--black-color)",
+  color: "var(--white-color)",
+};
+
+/**
+ * 画像を表示していない空のときにメッセージを表示するコンポーネント
+ */
+function EmptyMessage() {
+  return (
+    <div style={PLACEHOLDER_STYLE}>
+      以下のものをドロップしてください
+      <br />
+      <br />
+      画像をまとめた zip ファイル
+      <br />
+      画像ファイル
+      <br />
+      画像が入ったフォルダ
+    </div>
   );
 }

--- a/src/components/SingleImageView.tsx
+++ b/src/components/SingleImageView.tsx
@@ -68,7 +68,18 @@ export function SingleImageView({ source, isHalf, justify }: Props) {
   };
 
   if (!source) {
-    return <div style={PLACEHOLDER_STYLE}>画像ファイルまたはフォルダをドロップしてください</div>;
+    return (
+      <div style={PLACEHOLDER_STYLE}>
+        以下のものをドロップしてください
+        <br />
+        <br />
+        画像をまとめた zip ファイル
+        <br />
+        画像ファイル
+        <br />
+        画像が入ったフォルダ
+      </div>
+    );
   }
 
   const src =
@@ -131,6 +142,7 @@ const PLACEHOLDER_STYLE: React.CSSProperties = {
   display: "flex",
   alignItems: "center",
   justifyContent: "center",
+  textAlign: "center",
   userSelect: "none",
   "-webkit-user-select": "none",
   background: "var(--black-color)",

--- a/src/components/SingleImageView.tsx
+++ b/src/components/SingleImageView.tsx
@@ -68,18 +68,7 @@ export function SingleImageView({ source, isHalf, justify }: Props) {
   };
 
   if (!source) {
-    return (
-      <div style={PLACEHOLDER_STYLE}>
-        以下のものをドロップしてください
-        <br />
-        <br />
-        画像をまとめた zip ファイル
-        <br />
-        画像ファイル
-        <br />
-        画像が入ったフォルダ
-      </div>
-    );
+    return null;
   }
 
   const src =
@@ -135,19 +124,6 @@ export function SingleImageView({ source, isHalf, justify }: Props) {
     </div>
   );
 }
-
-/** 画像未表示時のスタイル */
-const PLACEHOLDER_STYLE: React.CSSProperties = {
-  height: "100%",
-  display: "flex",
-  alignItems: "center",
-  justifyContent: "center",
-  textAlign: "center",
-  userSelect: "none",
-  "-webkit-user-select": "none",
-  background: "var(--black-color)",
-  color: "var(--white-color)",
-};
 
 /** 1枚の画像 img のスタイル */
 const IMAGE_STYLE: React.CSSProperties = { height: "100%", objectFit: "contain" };


### PR DESCRIPTION
## 概要

画像を開いていないときに表示されている空メッセージを、実際に開く対象（zip ファイル等）を反映した内容に変更する。

また配置ファイルを変更するリファクタリングを行うとともに、スタイルを微調整する。

もともと | 変更後
-- | --
![image](https://github.com/user-attachments/assets/1482c76d-c825-4dfa-96f1-2d76aaa5175a) | ![image](https://github.com/user-attachments/assets/131d0835-7554-4620-8837-e82e1536421a)

