### PR TITLE
refactor: `TopMenu` から Tailwind を除去

### DIFF
--- a/src/components/TopMenu.tsx
+++ b/src/components/TopMenu.tsx
@@ -130,8 +130,8 @@ const ICON_BUTTON_COMMON_STYLE: CSSProperties = {
   flexDirection: "column",
   alignItems: "center",
   justifyContent: "center",
-  borderRadius: "0.375rem",
-  padding: "0.125rem 0.25rem",
+  borderRadius: "8px",
+  padding: "2px 0 1px",
   width: "3rem",
 };
 
@@ -165,7 +165,7 @@ function IconButton({
       <div>
         <img src={src} />
       </div>
-      {label && <div style={{ fontSize: "0.7rem" }}>{label}</div>}
+      {label && <div style={{ fontSize: "12px" }}>{label}</div>}
     </button>
   );
 }

--- a/src/components/TopMenu.tsx
+++ b/src/components/TopMenu.tsx
@@ -137,6 +137,10 @@ const ICON_BUTTON_COMMON_STYLE: CSSProperties = {
 
 const BUTTON_LABEL_STYLE: CSSProperties = {
   fontSize: "12px",
+  whiteSpace: "nowrap",
+  overflow: "hidden",
+  letterSpacing: "-0.05rem",
+  fontFeatureSettings: "palt",
 };
 
 /**

--- a/src/components/TopMenu.tsx
+++ b/src/components/TopMenu.tsx
@@ -10,7 +10,7 @@ const MENU_WRAPPER_STYLE: CSSProperties = {
   top: 0,
   left: 0,
   width: "100dvw",
-  color: "rgb(75 85 99)",
+  color: "hsl(180 10% 20%)",
 };
 
 /**
@@ -146,11 +146,11 @@ function IconButton({
 }) {
   const buttonStyle: CSSProperties = selected
     ? {
-        backgroundColor: "rgba(255, 255, 255, 0.8)",
-        boxShadow: "inset 0 0 0 3px rgba(59, 130, 246, 0.5)",
+        backgroundColor: "hsl(0 0% 100% / 80%)",
+        boxShadow: "inset 0 0 0 3px hsl(180 80% 50% / 0.5)",
       }
     : {
-        backgroundColor: "rgba(255, 255, 255, 0.3)",
+        backgroundColor: "hsl(0 0% 100% / 30%)",
         cursor: "pointer",
       };
 

--- a/src/components/TopMenu.tsx
+++ b/src/components/TopMenu.tsx
@@ -13,6 +13,14 @@ const MENU_WRAPPER_STYLE: CSSProperties = {
   color: "hsl(180 10% 20%)",
 };
 
+/** 上部メニューの中身を並べるスタイル */
+const MENU_BODY_STYLE: CSSProperties = {
+  display: "flex",
+  flexDirection: "row",
+  justifyContent: "center",
+  gap: "8px",
+};
+
 /**
  * 画面上部に表示する挙動切替メニューのコンポーネント
  *
@@ -40,9 +48,7 @@ export function TopMenu() {
       onMouseLeave={() => setIsVisible(false)}
     >
       {isVisible && (
-        <div
-          style={{ display: "flex", flexDirection: "row", justifyContent: "center", gap: "8px" }}
-        >
+        <div style={MENU_BODY_STYLE}>
           <SingleDoubleSwitcher />
           <PageDirectionSwitcher />
         </div>

--- a/src/components/TopMenu.tsx
+++ b/src/components/TopMenu.tsx
@@ -135,6 +135,10 @@ const ICON_BUTTON_COMMON_STYLE: CSSProperties = {
   width: "3rem",
 };
 
+const BUTTON_LABEL_STYLE: CSSProperties = {
+  fontSize: "12px",
+};
+
 /**
  * アイコンが付いたボタンのコンポーネント
  */
@@ -165,7 +169,7 @@ function IconButton({
       <div>
         <img src={src} />
       </div>
-      {label && <div style={{ fontSize: "12px" }}>{label}</div>}
+      {label && <div style={BUTTON_LABEL_STYLE}>{label}</div>}
     </button>
   );
 }

--- a/src/components/TopMenu.tsx
+++ b/src/components/TopMenu.tsx
@@ -1,8 +1,17 @@
-import { useState } from "react";
+import { useState, type CSSProperties } from "react";
 import { useAtom } from "jotai";
 import { pageDirectionAtom, singleOrDoubleAtom } from "../atoms/app";
 import { useHandleEvent } from "../hooks/event";
 import { AppEvent } from "../types/event";
+
+/** 上部メニューに常に割り当てるスタイル */
+const MENU_WRAPPER_STYLE: CSSProperties = {
+  position: "absolute",
+  top: 0,
+  left: 0,
+  width: "100dvw",
+  color: "rgb(75 85 99)",
+};
 
 /**
  * 画面上部に表示する挙動切替メニューのコンポーネント
@@ -12,18 +21,28 @@ import { AppEvent } from "../types/event";
 export function TopMenu() {
   const [isVisible, setIsVisible] = useState(false);
 
-  const wrapperClass = isVisible
-    ? "absolute top-0 left-0 w-dvw bg-white/30 backdrop-blur-sm text-neutral-700 p-2"
-    : "absolute top-0 left-0 w-dvw bg-transparent h-8";
+  // 表示/非表示状態に応じてスタイルを切替
+  const visibleStyle: CSSProperties = isVisible
+    ? {
+        backgroundColor: "hsl(0 0% 100% / 30%)",
+        backdropFilter: "blur(8px)",
+        padding: "0.5rem",
+      }
+    : {
+        backgroundColor: "transparent",
+        height: "3rem",
+      };
 
   return (
     <div
-      className={wrapperClass}
+      style={{ ...MENU_WRAPPER_STYLE, ...visibleStyle }}
       onMouseEnter={() => setIsVisible(true)}
       onMouseLeave={() => setIsVisible(false)}
     >
       {isVisible && (
-        <div className="flex flex-row justify-center gap-2">
+        <div
+          style={{ display: "flex", flexDirection: "row", justifyContent: "center", gap: "8px" }}
+        >
           <SingleDoubleSwitcher />
           <PageDirectionSwitcher />
         </div>
@@ -100,6 +119,16 @@ function PageDirectionSwitcher() {
   );
 }
 
+const ICON_BUTTON_COMMON_STYLE: CSSProperties = {
+  display: "flex",
+  flexDirection: "column",
+  alignItems: "center",
+  justifyContent: "center",
+  borderRadius: "0.375rem",
+  padding: "0.125rem 0.25rem",
+  width: "3rem",
+};
+
 /**
  * アイコンが付いたボタンのコンポーネント
  */
@@ -113,17 +142,24 @@ function IconButton({
   label?: string;
   selected?: boolean;
   onClick: () => void;
+  style?: CSSProperties;
 }) {
-  const buttonClass = selected
-    ? "bg-white/80 flex flex-col items-center justify-center rounded-md px-1 py-0.5 w-[3rem] inset-ring-3 inset-ring-blue-500/50"
-    : "bg-white/30 flex flex-col items-center justify-center rounded-md px-1 py-0.5 w-[3rem] cursor-pointer";
+  const buttonStyle: CSSProperties = selected
+    ? {
+        backgroundColor: "rgba(255, 255, 255, 0.8)",
+        boxShadow: "inset 0 0 0 3px rgba(59, 130, 246, 0.5)",
+      }
+    : {
+        backgroundColor: "rgba(255, 255, 255, 0.3)",
+        cursor: "pointer",
+      };
 
   return (
-    <button className={buttonClass} onClick={onClick}>
+    <button style={{ ...ICON_BUTTON_COMMON_STYLE, ...buttonStyle }} onClick={onClick}>
       <div>
         <img src={src} />
       </div>
-      {label && <div className="text-xs">{label}</div>}
+      {label && <div style={{ fontSize: "0.7rem" }}>{label}</div>}
     </button>
   );
 }


### PR DESCRIPTION
## 概要

上部メニューを表示する `TopMenu` コンポーネントから Tailwind を削除する。

ついでに以下の対応も実施。

- 共通スタイルの定数化。
- 色を中心にスタイル指定方法の整理。
- ラベルのスタイルの微調整。
