### PR TITLE
style: リネームボックスを中央に表示

### DIFF
--- a/src/components/RenameBox.tsx
+++ b/src/components/RenameBox.tsx
@@ -15,6 +15,8 @@ const RENAME_BOX_STYLE: CSSProperties = {
   top: "50%",
   left: "50%",
   transform: "translate(-50%, -50%)",
+  minWidth: "20%",
+  maxWidth: "30%",
   backgroundColor: "hsl(0 0% 100% / 0.6)",
   color: "hsl(180 10% 5%)",
   backdropFilter: "blur(8px)",
@@ -30,6 +32,7 @@ const FILE_NAME_STYLE: CSSProperties = {
 
 /** テキストボックスのスタイル */
 const TEXT_BOX_STYLE: CSSProperties = {
+  width: "100%",
   backgroundColor: "hsl(0 0% 100% / 0.6)",
   borderRadius: "0.5rem",
   padding: "0.5rem 0.25rem",
@@ -87,7 +90,6 @@ export function RenameBox() {
         <div>
           <input
             type="text"
-            size={100}
             style={TEXT_BOX_STYLE}
             ref={inputRef}
             defaultValue={defaultValue}

--- a/src/components/RenameBox.tsx
+++ b/src/components/RenameBox.tsx
@@ -38,7 +38,7 @@ const TEXT_BOX_STYLE: CSSProperties = {
   padding: "0.5rem 0.25rem",
   margin: "0.25rem 0",
   border: "1px solid hsl(180 10% 50%)",
-  fontSize: "1.6rem",
+  fontSize: "1.8rem",
 };
 
 /**

--- a/src/components/RenameBox.tsx
+++ b/src/components/RenameBox.tsx
@@ -12,9 +12,9 @@ import { AppEvent } from "../types/event";
 /** リネームボックスのスタイル */
 const RENAME_BOX_STYLE: CSSProperties = {
   position: "absolute",
-  bottom: "2rem",
+  top: "50%",
   left: "50%",
-  transform: "translateX(-50%)",
+  transform: "translate(-50%, -50%)",
   backgroundColor: "hsl(0 0% 100% / 0.6)",
   color: "hsl(180 10% 5%)",
   backdropFilter: "blur(8px)",


### PR DESCRIPTION
これまで画面下に表示していたリネームボックスを、画面中央に表示するように変更して見やすくする。

ついでに横幅を狭くし、フォントサイズを調整するなどで、視認性を向上させる。
