### PR TITLE
feat: 表示スケールの違いに対応してウィンドウの位置・サイズを復元

### DIFF
--- a/src/atoms/config.ts
+++ b/src/atoms/config.ts
@@ -1,6 +1,8 @@
 import { atom } from "jotai";
 import { WindowConfig, KeyboardConfig } from "../types/config";
 import { AppEvent } from "../types/event";
+import { PhysicalPosition, PhysicalSize } from "@tauri-apps/api/dpi";
+import { getCurrentWindow } from "@tauri-apps/api/window";
 
 /**
  * 右開きでのデフォルトのキーボード操作
@@ -175,9 +177,18 @@ export const windowPositionAtom = atom(
 /**
  * 保存するウィンドウの位置とサイズの設定データを返す atom
  */
-export const windowConfigDataAtom = atom((get) => {
+export const windowConfigDataAtom = atom(async (get) => {
+  const size = get($windowSizeAtom);
+  const position = get($windowPositionAtom);
+
+  // 表示スケールの違いに対応するため、物理位置・サイズから論理位置・サイズに変換して保存
+  const appWindow = getCurrentWindow();
+  const factor = await appWindow.scaleFactor();
+  const s = size == undefined ? undefined : new PhysicalSize(size).toLogical(factor);
+  const p = position == undefined ? undefined : new PhysicalPosition(position).toLogical(factor);
+
   return {
-    window: { size: get($windowSizeAtom), position: get($windowPositionAtom) },
+    window: { size: s, position: p },
   } satisfies WindowConfig;
 });
 


### PR DESCRIPTION
表示スケールが設定されていて物理位置・サイズと論理位置・サイズが異なる場合でも、正しくウィンドウの位置とサイズを復元可能にする。

これまでは単純に取得したピクセル数（物理）を保存しており、表示スケールが `1.0` でない場合には起動後のウィンドウ位置・サイズ復元時に異なる位置・サイズとなっていた。今回、表示スケールを反映した値を保存することにより、正しく復元可能とする。

環境によって色々違うので、まだ挙動がおかしい可能性はある。
