### PR TITLE
style: 上部メニューのスタイルを調整

### DIFF
--- a/src/components/TopMenu.tsx
+++ b/src/components/TopMenu.tsx
@@ -176,7 +176,7 @@ const ICON_BUTTON_COMMON_STYLE: CSSProperties = {
 };
 
 const BUTTON_LABEL_STYLE: CSSProperties = {
-  fontSize: "12px",
+  fontSize: "1.2rem",
   whiteSpace: "nowrap",
   overflow: "hidden",
   letterSpacing: "-0.05rem",
@@ -191,6 +191,9 @@ const SLIDESHOW_INTERVAL_INPUT_STYLE: CSSProperties = {
 const SLIDESHOW_INTERVAL_BOX_STYLE: CSSProperties = {
   display: "flex",
   alignItems: "center",
+  gap: "4px",
+  paddingLeft: "4px",
+  fontSize: "1.2rem",
   textShadow: "0 0 6px white",
 };
 

--- a/src/components/TopMenu.tsx
+++ b/src/components/TopMenu.tsx
@@ -10,23 +10,6 @@ import {
 import { useHandleEvent, useSlideshow } from "../hooks/event";
 import { AppEvent } from "../types/event";
 
-/** 上部メニューに常に割り当てるスタイル */
-const MENU_WRAPPER_STYLE: CSSProperties = {
-  position: "absolute",
-  top: 0,
-  left: 0,
-  width: "100dvw",
-  color: "hsl(180 10% 20%)",
-};
-
-/** 上部メニューの中身を並べるスタイル */
-const MENU_BODY_STYLE: CSSProperties = {
-  display: "flex",
-  flexDirection: "row",
-  justifyContent: "center",
-  gap: "8px",
-};
-
 /**
  * 画面上部に表示する挙動切替メニューのコンポーネント
  *
@@ -64,10 +47,21 @@ export function TopMenu() {
   );
 }
 
-/** 切替ボタンのグループのスタイル */
-const SWITCHER_STYLE: React.CSSProperties = {
+/** 上部メニューに常に割り当てるスタイル */
+const MENU_WRAPPER_STYLE: CSSProperties = {
+  position: "absolute",
+  top: 0,
+  left: 0,
+  width: "100dvw",
+  color: "hsl(180 10% 20%)",
+};
+
+/** 上部メニューの中身を並べるスタイル */
+const MENU_BODY_STYLE: CSSProperties = {
   display: "flex",
+  flexDirection: "row",
   justifyContent: "center",
+  gap: "8px",
 };
 
 /**
@@ -165,22 +159,10 @@ function SlideshowController() {
   );
 }
 
-const ICON_BUTTON_COMMON_STYLE: CSSProperties = {
+/** 切替ボタンのグループのスタイル */
+const SWITCHER_STYLE: React.CSSProperties = {
   display: "flex",
-  flexDirection: "column",
-  alignItems: "center",
   justifyContent: "center",
-  borderRadius: "8px",
-  padding: "2px 0 1px",
-  width: "5rem",
-};
-
-const BUTTON_LABEL_STYLE: CSSProperties = {
-  fontSize: "1.2rem",
-  whiteSpace: "nowrap",
-  overflow: "hidden",
-  letterSpacing: "-0.05rem",
-  fontFeatureSettings: "palt",
 };
 
 const SLIDESHOW_INTERVAL_INPUT_STYLE: CSSProperties = {
@@ -257,3 +239,21 @@ function IconButton({
     </button>
   );
 }
+
+const ICON_BUTTON_COMMON_STYLE: CSSProperties = {
+  display: "flex",
+  flexDirection: "column",
+  alignItems: "center",
+  justifyContent: "center",
+  borderRadius: "8px",
+  padding: "2px 0 1px",
+  width: "5rem",
+};
+
+const BUTTON_LABEL_STYLE: CSSProperties = {
+  fontSize: "1.2rem",
+  whiteSpace: "nowrap",
+  overflow: "hidden",
+  letterSpacing: "-0.05rem",
+  fontFeatureSettings: "palt",
+};


### PR DESCRIPTION
上部メニューの一部のスタイルを調整して見やすくする。

ついでに軽いリファクタリングも実施し、スタイルの定数のコンポーネント外での定義箇所を、コンポーネントの後に移動させる。この方が個人的には分かりやすい気がする。使っている箇所が先に出てくるので。
