### PR TITLE
feat: 画像表示時のコンテキストメニューを実装

### DIFF
--- a/src/atoms/app.ts
+++ b/src/atoms/app.ts
@@ -1,6 +1,16 @@
 import { atom } from "jotai";
 import { ViewImageMode } from "../types/image";
 import { AppViewMode } from "../types/app";
+import {
+  isFirstPageAtom as zipFirstPageAtom,
+  isLastPageAtom as zipLastPageAtom,
+  isOpenZipAtom as zipOpenAtom,
+} from "./zip";
+import {
+  isOpenImageAtom as imageOpenAtom,
+  isFirstPageAtom as imageFirstPageAtom,
+  isLastPageAtom as imageLastPageAtom,
+} from "./image";
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
 アプリケーション全体の状態を管理する atom を集めたファイル
@@ -53,6 +63,38 @@ export const isMagnifierEnabledAtom = atom<boolean>(false);
  * デフォルトでは左に進む（右開き）で `"left"`
  */
 export const pageDirectionAtom = atom<"right" | "left">("left");
+
+// =  =  =  =  =  =  =  =  =  =  =  =  =  =  =  =  =  =  =  =  =  =  =  =  =  =  =  =  =  =  =  =
+// #region 画像情報取得関連
+// =  =  =  =  =  =  =  =  =  =  =  =  =  =  =  =  =  =  =  =  =  =  =  =  =  =  =  =  =  =  =  =
+
+/**
+ * 画像を表示しているかどうかを取得する atom
+ */
+export const isOpenPageAtom = atom((get) => {
+  const mode = get(appModeAtom);
+  return mode === "zip" ? get(zipOpenAtom) : get(imageOpenAtom);
+});
+
+/**
+ * 最初のページを表示しているかどうかを取得する atom
+ *
+ * 画像を表示していないときは false を返す
+ */
+export const isFirstPageAtom = atom((get) => {
+  const mode = get(appModeAtom);
+  return mode === "zip" ? get(zipFirstPageAtom) : get(imageFirstPageAtom);
+});
+
+/**
+ * 最後のページを表示しているかどうかを取得する atom
+ *
+ * 画像を表示していないときは false を返す
+ */
+export const isLastPageAtom = atom((get) => {
+  const mode = get(appModeAtom);
+  return mode === "zip" ? get(zipLastPageAtom) : get(imageLastPageAtom);
+});
 
 // =  =  =  =  =  =  =  =  =  =  =  =  =  =  =  =  =  =  =  =  =  =  =  =  =  =  =  =  =  =  =  =
 // #region スライドショー関連

--- a/src/atoms/image.ts
+++ b/src/atoms/image.ts
@@ -75,6 +75,55 @@ export const openImagePathAtom = atom(null, async (_, set, path: string) => {
   }
 });
 
+/**
+ * 画像を表示しているかどうかを取得する atom
+ */
+export const isOpenImageAtom = atom((get) => {
+  const list = get($imagePathListAtom);
+  return 0 < list.length;
+});
+
+/**
+ * 最初のページを表示しているかどうかを取得する atom
+ *
+ * 画像を表示していないときは false を返す
+ */
+export const isFirstPageAtom = atom((get) => {
+  if (!get(isOpenImageAtom)) {
+    return false;
+  }
+  const index = get($openingIndexAtom);
+  return index === 0;
+});
+
+/**
+ * 最後のページを表示しているかどうかを取得する atom
+ *
+ * 画像を表示していないときは false を返す
+ */
+export const isLastPageAtom = atom((get) => {
+  if (!get(isOpenImageAtom)) {
+    return false;
+  }
+  const imageList = get($imagePathListAtom);
+  const index = get($openingIndexAtom);
+  // 最後の画像を1枚のみ表示している場合は true
+  if (index === imageList.length - 1) {
+    return true;
+  }
+  // 最後の2枚より前を表示している場合は false
+  if (index < imageList.length - 2) {
+    return false;
+  }
+  // 最後から2枚目をインデックスが示しているとき、見開き表示かどうかを加味して判定
+  const imageProperty = get(viewingImageAtom);
+  // 一応、画像情報がないときは false を返しておく
+  if (!imageProperty) {
+    return false;
+  }
+  return imageProperty.type === "double";
+});
+
 // -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -
 // イベント系
 

--- a/src/atoms/zip.ts
+++ b/src/atoms/zip.ts
@@ -182,10 +182,58 @@ const setOpeningArchivePathAtom = atom(null, (_, set, path: string) => {
 });
 
 /**
+ * zip ファイルを開いているかどうかを取得する atom
+ */
+export const isOpenZipAtom = atom((get) => {
+  return get($openingZipDataAtom) !== undefined;
+});
+
+/**
  * アーカイブ内の画像のパスの一覧を取得する atom
  */
 export const imageListAtom = atom((get) => {
   return get($imageNameListAtom);
+});
+
+/**
+ * 最初のページを表示しているかどうかを取得する atom
+ *
+ * zip ファイルを開いていないときは false を返す
+ */
+export const isFirstPageAtom = atom((get) => {
+  if (!get(isOpenZipAtom)) {
+    return false;
+  }
+  const index = get($openingImageIndexAtom);
+  return index === 0;
+});
+
+/**
+ * 最後のページを表示しているかどうかを取得する atom
+ *
+ * zip ファイルを開いていないときは false を返す
+ */
+export const isLastPageAtom = atom((get) => {
+  if (!get(isOpenZipAtom)) {
+    return false;
+  }
+  const imageList = get($imageNameListAtom);
+  const index = get($openingImageIndexAtom);
+  // 最後の画像を1枚のみ表示している場合は true
+  if (index === imageList.length - 1) {
+    return true;
+  }
+  // 最後の2枚より前を表示している場合は false
+  if (index < imageList.length - 2) {
+    return false;
+  }
+  // 最後から2枚目をインデックスが示しているとき、見開き表示かどうかを加味して判定
+  const imageProperty = get(viewingImageAtom);
+  // 一応、画像情報がないときは false を返しておく
+  if (!imageProperty) {
+    return false;
+  }
+  return imageProperty.type === "double";
 });
 
 /**


### PR DESCRIPTION
画像を表示しているビューに対してのコンテキストメニューを実装する。

ひとまずページ移動とフルスクリーンを可能にしている。
