### PR TITLE
refactor: 前後ページへの移動可否判定を atom へ整理し、コンテキストメニューで使用する

### DIFF
--- a/src/atoms/app.ts
+++ b/src/atoms/app.ts
@@ -96,6 +96,20 @@ export const isLastPageAtom = atom((get) => {
   return mode === "zip" ? get(zipLastPageAtom) : get(imageLastPageAtom);
 });
 
+/**
+ * 前のページへ移動可能かどうかを取得する atom
+ */
+export const canMovePrevAtom = atom((get) => {
+  return get(isOpenPageAtom) && !get(isFirstPageAtom);
+});
+
+/**
+ * 次のページへ移動可能かどうかを取得する atom
+ */
+export const canMoveNextAtom = atom((get) => {
+  return get(isOpenPageAtom) && !get(isLastPageAtom);
+});
+
 // =  =  =  =  =  =  =  =  =  =  =  =  =  =  =  =  =  =  =  =  =  =  =  =  =  =  =  =  =  =  =  =
 // #region スライドショー関連
 // =  =  =  =  =  =  =  =  =  =  =  =  =  =  =  =  =  =  =  =  =  =  =  =  =  =  =  =  =  =  =  =

--- a/src/components/ImageView.tsx
+++ b/src/components/ImageView.tsx
@@ -1,9 +1,8 @@
 import { CSSProperties } from "react";
 import { useAtomValue } from "jotai";
 import {
-  isFirstPageAtom,
-  isLastPageAtom,
-  isOpenPageAtom,
+  canMoveNextAtom,
+  canMovePrevAtom,
   pageDirectionAtom,
   viewingImageAtom,
 } from "../atoms/app";
@@ -109,9 +108,8 @@ function EmptyMessage() {
  */
 function useContextMenu() {
   const handleEvent = useHandleEvent();
-  const isFirstPage = useAtomValue(isFirstPageAtom);
-  const isLastPage = useAtomValue(isLastPageAtom);
-  const isOpen = useAtomValue(isOpenPageAtom);
+  const canMoveNext = useAtomValue(canMoveNextAtom);
+  const canMovePrev = useAtomValue(canMovePrevAtom);
 
   // 有効/無効の切り替えに、前後ページの有無を反転して使用しているため、開いているかどうかも条件に含めている
   const menuPromise = Menu.new({
@@ -120,13 +118,13 @@ function useContextMenu() {
         text: "次のページ",
         icon: "GoLeft",
         action: () => handleEvent(AppEvent.MOVE_NEXT_PAGE),
-        enabled: isOpen && !isLastPage,
+        enabled: canMoveNext,
       },
       {
         text: "前のページ",
         icon: "GoRight",
         action: () => handleEvent(AppEvent.MOVE_PREV_PAGE),
-        enabled: isOpen && !isFirstPage,
+        enabled: canMovePrev,
       },
       {
         item: "Separator",
@@ -134,12 +132,12 @@ function useContextMenu() {
       {
         text: "最後のページ",
         action: () => handleEvent(AppEvent.MOVE_LAST_PAGE),
-        enabled: isOpen && !isLastPage,
+        enabled: canMoveNext,
       },
       {
         text: "最初のページ",
         action: () => handleEvent(AppEvent.MOVE_FIRST_PAGE),
-        enabled: isOpen && !isFirstPage,
+        enabled: canMovePrev,
       },
       {
         item: "Separator",


### PR DESCRIPTION
前後ページへの移動可否判定を atom にまとめ、コンテキストメニューの移動系項目の有効/無効の切替をこの atom を使用する。

## モチベーション

コンテキストメニューの前後ページへの移動を行う項目は、移動可否に応じて有効/無効を切り替えている。

移動可否の判定を行うに当たり、これまでは以下の2つの条件をコンテキストメニューで見ていた。

- ファイルを開いているかどうか
- 最初/最後のページを表示しているかどうか

今後、アプリの上部メニューでも同様の判定を行っていくにあたり、記載が2箇所に分散しているのは望ましくないため、atom として1箇所にまとめる。
