### PR TITLE
feat: 表示内容の統一のため、コンテキストメニューのアイコンを削除

### DIFF
--- a/src/components/ImageView.tsx
+++ b/src/components/ImageView.tsx
@@ -116,13 +116,11 @@ function useContextMenu() {
     items: [
       {
         text: "次のページ",
-        icon: "GoLeft",
         action: () => handleEvent(AppEvent.MOVE_NEXT_PAGE),
         enabled: canMoveNext,
       },
       {
         text: "前のページ",
-        icon: "GoRight",
         action: () => handleEvent(AppEvent.MOVE_PREV_PAGE),
         enabled: canMovePrev,
       },


### PR DESCRIPTION
以下の理由から、コンテキストメニューの項目をアイコンなしに統一する。

- それぞれのメニューアイテムに合致するデザインのアイコンを探す手間がかかる。（特にデフォルトアイコン以外）
- メニュー（コンテキストメニューも含む）のアイコンは PNG 形式しか対応していないため、作成に手間がかかる。（色の合致、サイズの合致、変換処理）
- そもそもアイコンがあっても特に嬉しくはない。

