### PR TITLE
feat: 同名ファイルへのリネームではアンダースコアを追加しないように変更

### DIFF
--- a/src/atoms/zip.ts
+++ b/src/atoms/zip.ts
@@ -676,10 +676,8 @@ const renameArchiveAtom = atom(null, async (get, set, name: string) => {
   if (!beforePath) {
     return;
   }
-  console.log(name);
 
   const newPath = await createRenamedPathToExcludeExtensionName(beforePath, name);
-  console.log(newPath);
 
   // リネームして、変更後のファイル名を開いていることにする
   rename(beforePath, newPath);

--- a/src/utils/files.test.ts
+++ b/src/utils/files.test.ts
@@ -171,4 +171,11 @@ describe("createRenamedPathToExcludeExtensionName", () => {
       await createRenamedPathToExcludeExtensionName("/a/b/元の名前.txt", "ピリオドの前.と後")
     ).toBe("/a/b/ピリオドの前.と後_.txt");
   });
+
+  test("前後のファイル名が同じ場合、アンダースコアが付与していないパスが返されること", async () => {
+    vi.mocked(exists).mockReturnValue(Promise.resolve(true));
+    expect(await createRenamedPathToExcludeExtensionName("/a/b/元の名前.txt", "元の名前")).toBe(
+      "/a/b/元の名前.txt"
+    );
+  });
 });

--- a/src/utils/files.ts
+++ b/src/utils/files.ts
@@ -153,6 +153,10 @@ export async function createRenamedPathToExcludeExtensionName(
   let newName = ext ? `${name}.${ext}` : name; // 新しいファイル名の拡張子を含んだ部分
   let newPath = [...buf, newName].join("/");
 
+  if (beforeName === newName) {
+    return path;
+  }
+
   // 変更後のファイル名がすでに存在している場合、ファイル名と拡張子に分割し、ファイル名の末尾に `_` を付与してから結合して戻す
   while (await exists(newPath)) {
     newBody = `${newBody}_`;


### PR DESCRIPTION
これまで RenameView においてリネーム操作を行うとき、名前を変更せずにエンターを押下すると、アンダースコアが付与される挙動となっていた。（当該ファイルがすでに存在すると判定されるため）

しかし不要な挙動であるため、同名ファイルへのリネームではアンダースコアを追加しないように変更する。

また同時に発見した、不要な `console.log` 出力を削除する。
