### PR TITLE
feat: ウィンドウの設定ファイルの破損を防ぐ

### DIFF
--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -72,6 +72,11 @@ export async function storeConfigFile(config: WindowConfig, name: string) {
   const dir = await appConfigDir(); // macOS では /Users/{username}/Library/Application Support/{identifier}
   const path = await join(dir, name);
 
+  // 設定ファイルの破損を防ぐため、保存対象のデータがない場合は保存しない
+  if (config.window?.position == null || config.window?.size == null) {
+    return;
+  }
+
   // 保存先のディレクトリが存在しないときは作成する
   if (!(await exists(dir))) {
     await mkdir(dir);


### PR DESCRIPTION
ウィンドウ位置の設定ファイルの保存時、内容が破損しないように、中身のデータがあるときのみ保存を行うようにする。

ウィンドウ位置の設定ファイルが稀に破損することがあり、そのときの中身は空のオブジェクトとなっていることが多い。再現条件は不明だが（起動直後の挙動が怪しいと睨んでいるが詳細は不明）、ひとまず中身があるときのみファイルを保存する挙動とする。
