### PR TITLE
refactor: イベント処理をカスタムフックから atom へ変更

### DIFF
--- a/src/atoms/event.ts
+++ b/src/atoms/event.ts
@@ -1,0 +1,91 @@
+import { atom } from "jotai";
+import {
+  isOpeningRenameViewAtom,
+  isMagnifierEnabledAtom,
+  appModeAtom,
+  pageDirectionAtom,
+} from "./app";
+import { keyboardConfigAtom } from "./config";
+import { handleAppEvent as handleEventZip } from "./zip";
+import { handleAppEvent as handleEventImage } from "./image";
+import { AppEvent } from "../types/event";
+import { KeyboardConfig } from "../types/config";
+import { getHorizontalSwitchEvent } from "../utils/event";
+
+/**
+ * イベントを処理する atom
+ *
+ * ユーザー操作や、実行したいイベントそのものを渡すことで、イベントを発行する。
+ *
+ * TODO: 必要に応じて payload を受け取れるようにする
+ */
+export const handleEventAtom = atom<
+  null,
+  [KeyboardEvent | MouseEvent | WheelEvent | AppEvent],
+  void
+>(null, async (get, set, event) => {
+  const keyboardConfig = get(keyboardConfigAtom);
+  const openingRenameView = get(isOpeningRenameViewAtom);
+  const isMagnifierEnabled = get(isMagnifierEnabledAtom);
+  const appMode = get(appModeAtom);
+  const pageDirection = get(pageDirectionAtom);
+
+  // アプリの動作モード(開いている種類)によりイベント送信先を切り替える
+  const eventHandleAtom = appMode === "zip" ? handleEventZip : handleEventImage;
+
+  if (event instanceof KeyboardEvent) {
+    const ev = convertKeyboardEvent(event, keyboardConfig, pageDirection);
+    if (ev) {
+      if (ev === AppEvent.OPEN_RENAME_VIEW && appMode === "zip") {
+        // 画像表示モードのときはリネームビューを表示しない
+        set(isOpeningRenameViewAtom, !openingRenameView);
+      } else {
+        set(eventHandleAtom, ev);
+      }
+    }
+  } else if (event instanceof WheelEvent) {
+    // TODO: ホイールイベントはページ移動のみに決め打ちしているので、カスタマイズ可能にする
+    if (0 < event.deltaY) {
+      set(eventHandleAtom, AppEvent.MOVE_NEXT_PAGE);
+    } else if (event.deltaY < 0) {
+      set(eventHandleAtom, AppEvent.MOVE_PREV_PAGE);
+    }
+  } else if (event instanceof MouseEvent) {
+    // ホイールがクリックされたときは、ルーペの有効/無効を切り替える
+    if (event.button === 1) {
+      set(isMagnifierEnabledAtom, !isMagnifierEnabled);
+    }
+  } else {
+    // ここでは AppEvent に絞り込まれているので、渡されたイベントを直接実行する
+    set(eventHandleAtom, event);
+  }
+});
+
+/**
+ * キーボード操作をイベントへ変換する
+ *
+ * 変換できなかったときは undefined を返す
+ */
+function convertKeyboardEvent(
+  input: KeyboardEvent,
+  config: KeyboardConfig[],
+  pageDirection: "left" | "right"
+): AppEvent | undefined {
+  for (const c of config) {
+    if (
+      input.key === c.key &&
+      input.ctrlKey === c.ctrl &&
+      input.shiftKey === c.shift &&
+      input.metaKey === c.meta
+    ) {
+      const ev = c.event;
+      // 左右反転
+      if (pageDirection === "right" && c.isHorizontalSwitch) {
+        return getHorizontalSwitchEvent(ev);
+      } else {
+        return ev;
+      }
+    }
+  }
+  return undefined;
+}

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -7,7 +7,6 @@ import { openZipAtom } from "../atoms/zip";
 import { useRestoreWindowConfig, useStoreWindowConfig, useWindowEvent } from "../hooks/config";
 import { ImageView } from "./ImageView";
 import { Indicator } from "./Indicator";
-import { useHandleEvent } from "../hooks/event";
 import { RenameBox } from "./RenameBox";
 import {
   canMoveNextAtom,
@@ -20,6 +19,7 @@ import { TopMenu } from "./TopMenu";
 import { getPathKind } from "../utils/files";
 import { openImagePathAtom } from "../atoms/image";
 import { AppEvent } from "../types/event";
+import { handleEventAtom } from "../atoms/event";
 
 const APP_STYLE: CSSProperties = {
   height: "100dvh",
@@ -60,7 +60,7 @@ function useEventListener() {
   const openImage = useSetAtom(openImagePathAtom);
   const { windowResized, windowMoved } = useWindowEvent();
   const storeConfig = useStoreWindowConfig();
-  const handleEvent = useHandleEvent();
+  const handleEvent = useSetAtom(handleEventAtom);
 
   // ファイルがドロップされたときの処理
   const handleDrop = useCallback(
@@ -147,7 +147,7 @@ function useEventListener() {
  * アプリのメニューを表示するカスタムフック
  */
 function useAppMenu() {
-  const handleEvent = useHandleEvent();
+  const handleEvent = useSetAtom(handleEventAtom);
   const canMoveNext = useAtomValue(canMoveNextAtom);
   const canMovePrev = useAtomValue(canMovePrevAtom);
   const isOpenPage = useAtomValue(isOpenPageAtom);

--- a/src/components/ImageView.tsx
+++ b/src/components/ImageView.tsx
@@ -1,5 +1,5 @@
 import { CSSProperties } from "react";
-import { useAtomValue } from "jotai";
+import { useAtomValue, useSetAtom } from "jotai";
 import {
   canMoveNextAtom,
   canMovePrevAtom,
@@ -8,8 +8,8 @@ import {
 } from "../atoms/app";
 import { SingleImageView } from "./SingleImageView";
 import { Menu } from "@tauri-apps/api/menu";
-import { useHandleEvent } from "../hooks/event";
 import { AppEvent } from "../types/event";
+import { handleEventAtom } from "../atoms/event";
 
 /**
  * 画像を表示するコンポーネント
@@ -109,7 +109,7 @@ function EmptyMessage() {
  * コンテキストメニューを生成するカスタムフック
  */
 function useContextMenu() {
-  const handleEvent = useHandleEvent();
+  const handleEvent = useSetAtom(handleEventAtom);
   const canMoveNext = useAtomValue(canMoveNextAtom);
   const canMovePrev = useAtomValue(canMovePrevAtom);
 

--- a/src/components/TopMenu.tsx
+++ b/src/components/TopMenu.tsx
@@ -1,5 +1,5 @@
 import { useState, type CSSProperties } from "react";
-import { useAtom, useAtomValue } from "jotai";
+import { useAtom, useAtomValue, useSetAtom } from "jotai";
 import {
   isSlideshowRunningAtom,
   pageDirectionAtom,
@@ -7,8 +7,9 @@ import {
   slideshowIntervalAtom,
   viewingImageAtom,
 } from "../atoms/app";
-import { useHandleEvent, useSlideshow } from "../hooks/event";
+import { useSlideshow } from "../hooks/event";
 import { AppEvent } from "../types/event";
+import { handleEventAtom } from "../atoms/event";
 
 /**
  * 画面上部に表示する挙動切替メニューのコンポーネント
@@ -69,7 +70,7 @@ const MENU_BODY_STYLE: CSSProperties = {
  */
 function SingleDoubleSwitcher() {
   const [singleOrDouble, setSingleOrDouble] = useAtom(singleOrDoubleAtom);
-  const handleEvent = useHandleEvent();
+  const handleEvent = useSetAtom(handleEventAtom);
 
   return (
     <div style={SWITCHER_STYLE}>
@@ -100,7 +101,7 @@ function SingleDoubleSwitcher() {
  */
 function PageDirectionSwitcher() {
   const [pageDirection, setPageDirection] = useAtom(pageDirectionAtom);
-  const handleEvent = useHandleEvent();
+  const handleEvent = useSetAtom(handleEventAtom);
 
   return (
     <div style={SWITCHER_STYLE}>

--- a/src/hooks/event.ts
+++ b/src/hooks/event.ts
@@ -1,113 +1,14 @@
 import { useCallback, useEffect } from "react";
 import { useAtom, useAtomValue, useSetAtom } from "jotai";
 import { AppEvent } from "../types/event";
-import { handleAppEvent as handleEventZip } from "../atoms/zip";
-import { handleAppEvent as handleEventImage } from "../atoms/image";
-import { keyboardConfigAtom } from "../atoms/config";
-import { KeyboardConfig } from "../types/config";
 import {
-  appModeAtom,
-  isMagnifierEnabledAtom,
-  isOpeningRenameViewAtom,
-  pageDirectionAtom,
   resetSlideshowAtom,
   slideshowCountAtom,
   slideshowIntervalAtom,
   slideshowIntervalIdAtom,
   stopSlideshowAtom,
 } from "../atoms/app";
-import { getHorizontalSwitchEvent } from "../utils/event";
-
-/**
- * ユーザー操作等により発生したイベントによりアプリ操作を行うカスタムフック
- */
-export function useHandleEvent() {
-  const [keyboardConfig] = useAtom(keyboardConfigAtom);
-  const [, handleZip] = useAtom(handleEventZip);
-  const handleImage = useSetAtom(handleEventImage);
-  const [openingRenameView, setOpeningRenameView] = useAtom(isOpeningRenameViewAtom);
-  const [isMagnifierEnabled, setIsMagnifierEnabled] = useAtom(isMagnifierEnabledAtom);
-  const appMode = useAtomValue(appModeAtom);
-  const pageDirection = useAtomValue(pageDirectionAtom);
-
-  // アプリの動作モードによりイベント送信先を切り替える
-  const eventHandler = appMode === "zip" ? handleZip : handleImage;
-
-  const handleEvent = useCallback(
-    (
-      event: KeyboardEvent | MouseEvent | WheelEvent | AppEvent
-      //payload?: number | string
-    ) => {
-      if (event instanceof KeyboardEvent) {
-        const ev = convertKeyboardEvent(event, keyboardConfig, pageDirection);
-        if (ev) {
-          if (ev === AppEvent.OPEN_RENAME_VIEW && appMode === "zip") {
-            // 画像表示モードのときはリネームビューを表示しない
-            setOpeningRenameView(!openingRenameView);
-          } else {
-            eventHandler(ev);
-          }
-        }
-      } else if (event instanceof WheelEvent) {
-        // TODO: ホイールイベントはページ移動のみに決め打ちしているので、カスタマイズ可能にする
-        if (0 < event.deltaY) {
-          eventHandler(AppEvent.MOVE_NEXT_PAGE);
-        } else if (event.deltaY < 0) {
-          eventHandler(AppEvent.MOVE_PREV_PAGE);
-        }
-      } else if (event instanceof MouseEvent) {
-        // ホイールがクリックされたときは、ルーペの有効/無効を切り替える
-        if (event.button === 1) {
-          setIsMagnifierEnabled(!isMagnifierEnabled);
-        }
-      } else {
-        // ここでは AppEvent に絞り込まれているので、渡されたイベントを直接実行する
-        eventHandler(event);
-      }
-    },
-    [
-      appMode,
-      eventHandler,
-      isMagnifierEnabled,
-      keyboardConfig,
-      openingRenameView,
-      pageDirection,
-      setIsMagnifierEnabled,
-      setOpeningRenameView,
-    ]
-  );
-
-  return handleEvent;
-}
-
-/**
- * キーボード操作をイベントへ変換する
- *
- * 変換できなかったときは undefined を返す
- */
-function convertKeyboardEvent(
-  input: KeyboardEvent,
-  config: KeyboardConfig[],
-  pageDirection: "left" | "right"
-): AppEvent | undefined {
-  for (const c of config) {
-    if (
-      input.key === c.key &&
-      input.ctrlKey === c.ctrl &&
-      input.shiftKey === c.shift &&
-      input.metaKey === c.meta
-    ) {
-      const ev = c.event;
-      // 左右反転
-      if (pageDirection === "right" && c.isHorizontalSwitch) {
-        return getHorizontalSwitchEvent(ev);
-      } else {
-        return ev;
-      }
-    }
-  }
-  return undefined;
-}
+import { handleEventAtom } from "../atoms/event";
 
 // =  =  =  =  =  =  =  =  =  =  =  =  =  =  =  =  =  =  =  =  =  =  =  =  =  =  =  =  =  =  =  =
 // #region スライドショー関連
@@ -119,7 +20,7 @@ function convertKeyboardEvent(
 export function useSlideshow() {
   const setCount = useSetAtom(slideshowCountAtom);
   const [intervalId, setIntervalId] = useAtom(slideshowIntervalIdAtom);
-  const handleEvent = useHandleEvent();
+  const handleEvent = useSetAtom(handleEventAtom);
   const stopSlideshow = useSetAtom(stopSlideshowAtom);
   const resetSlideshow = useSetAtom(resetSlideshowAtom);
   const slideshowInterval = useAtomValue(slideshowIntervalAtom);


### PR DESCRIPTION
これまでユーザー操作等により発生するイベント処理をカスタムフックで行っていたが、jotai の atom に変更する。

## モチベーション

カスタムフックでイベントを処理していたということは、イベント発火は React コンポーネントからのみ可能だった。

これを atom による処理に変更することで、引き続き React コンポーネントからはもちろん、別の atom からのイベント発火も可能となる。つまりデータに応じてイベントを実行することが可能になり、機能の可能性が広がる。
