### PR TITLE
chore: import 順を自動制御する eslint ルールを導入

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,8 +1,9 @@
-import globals from "globals";
 import pluginJs from "@eslint/js";
-import tseslint from "typescript-eslint";
+import importPlugin from "eslint-plugin-import";
 import pluginReact from "eslint-plugin-react";
 import reactHooks from "eslint-plugin-react-hooks";
+import globals from "globals";
+import tseslint from "typescript-eslint";
 
 /** @type {import('eslint').Linter.Config[]} */
 export default [
@@ -20,6 +21,27 @@ export default [
       "react/react-in-jsx-scope": "off",
       "react/jsx-uses-react": "off",
       ...reactHooks.configs.recommended.rules,
+    },
+  },
+  {
+    plugins: { import: importPlugin },
+    rules: {
+      "import/order": [
+        "warn",
+        {
+          groups: [
+            "builtin",
+            "external",
+            "parent",
+            "sibling",
+            "index",
+            "object",
+            // "type",
+          ],
+          pathGroupsExcludedImportTypes: ["builtin"],
+          alphabetize: { order: "asc" }, // グループ内で昇順にソート
+        },
+      ],
     },
   },
 ];

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@types/react-dom": "^18.3.6",
     "@vitejs/plugin-react": "^4.3.4",
     "eslint": "^9.24.0",
+    "eslint-plugin-import": "^2.31.0",
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^5.2.0",
     "globals": "^15.15.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,6 +54,9 @@ importers:
       eslint:
         specifier: ^9.24.0
         version: 9.24.0(jiti@2.4.2)
+      eslint-plugin-import:
+        specifier: ^2.31.0
+        version: 2.31.0(@typescript-eslint/parser@8.29.1(eslint@9.24.0(jiti@2.4.2))(typescript@5.6.3))(eslint@9.24.0(jiti@2.4.2))
       eslint-plugin-react:
         specifier: ^7.37.5
         version: 7.37.5(eslint@9.24.0(jiti@2.4.2))
@@ -507,6 +510,9 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@rtsao/scc@1.1.0':
+    resolution: {integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==}
+
   '@tauri-apps/api@2.4.1':
     resolution: {integrity: sha512-5sYwZCSJb6PBGbBL4kt7CnE5HHbBqwH+ovmOW6ZVju3nX4E3JX6tt2kRklFEH7xMOIwR0btRkZktuLhKvyEQYg==}
 
@@ -626,6 +632,9 @@ packages:
 
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
+
+  '@types/json5@0.0.29':
+    resolution: {integrity: sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==}
 
   '@types/prop-types@15.7.14':
     resolution: {integrity: sha512-gNMvNH49DJ7OJYv+KAKn0Xp45p8PLl6zo2YnvDIbTd4J6MER2BmWN49TG7n9LvkyihINxeKW8+3bfS2yDC9dzQ==}
@@ -763,6 +772,10 @@ packages:
     resolution: {integrity: sha512-CVvd6FHg1Z3POpBLxO6E6zr+rSKEQ9L6rZHAaY7lLfhKsWYUBBOuMs0e9o24oopj6H+geRCX0YJ+TJLBK2eHyQ==}
     engines: {node: '>= 0.4'}
 
+  array.prototype.findlastindex@1.2.6:
+    resolution: {integrity: sha512-F/TKATkzseUExPlfvmwQKGITM3DGTK+vkAsCZoDc5daVygbJBnjEUCbgkAvVFsgfXfX4YIqZ/27G3k3tdXrTxQ==}
+    engines: {node: '>= 0.4'}
+
   array.prototype.flat@1.3.3:
     resolution: {integrity: sha512-rwG/ja1neyLqCuGZ5YYrznA62D4mZXg0i1cIskIUKSiqF3Cje9/wXAls9B9s1Wa2fomMsIv8czB8jZcPmxCXFg==}
     engines: {node: '>= 0.4'}
@@ -876,6 +889,14 @@ packages:
     resolution: {integrity: sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==}
     engines: {node: '>= 0.4'}
 
+  debug@3.2.7:
+    resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
   debug@4.4.0:
     resolution: {integrity: sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==}
     engines: {node: '>=6.0'}
@@ -969,6 +990,40 @@ packages:
   escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
+
+  eslint-import-resolver-node@0.3.9:
+    resolution: {integrity: sha512-WFj2isz22JahUv+B788TlO3N6zL3nNJGU8CcZbPZvVEkBPaJdCV4vy5wyghty5ROFbCRnm132v8BScu5/1BQ8g==}
+
+  eslint-module-utils@2.12.0:
+    resolution: {integrity: sha512-wALZ0HFoytlyh/1+4wuZ9FJCD/leWHQzzrxJ8+rebyReSLk7LApMyd3WJaLVoN+D5+WIdJyDK1c6JnE65V4Zyg==}
+    engines: {node: '>=4'}
+    peerDependencies:
+      '@typescript-eslint/parser': '*'
+      eslint: '*'
+      eslint-import-resolver-node: '*'
+      eslint-import-resolver-typescript: '*'
+      eslint-import-resolver-webpack: '*'
+    peerDependenciesMeta:
+      '@typescript-eslint/parser':
+        optional: true
+      eslint:
+        optional: true
+      eslint-import-resolver-node:
+        optional: true
+      eslint-import-resolver-typescript:
+        optional: true
+      eslint-import-resolver-webpack:
+        optional: true
+
+  eslint-plugin-import@2.31.0:
+    resolution: {integrity: sha512-ixmkI62Rbc2/w8Vfxyh1jQRTdRTF52VxwRVHl/ykPAmqG+Nb7/kNn+byLP0LxPgI7zWA16Jt82SybJInmMia3A==}
+    engines: {node: '>=4'}
+    peerDependencies:
+      '@typescript-eslint/parser': '*'
+      eslint: ^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8 || ^9
+    peerDependenciesMeta:
+      '@typescript-eslint/parser':
+        optional: true
 
   eslint-plugin-react-hooks@5.2.0:
     resolution: {integrity: sha512-+f15FfK64YQwZdJNELETdn5ibXEUQmW1DZL6KXhNnc2heoy/sg9VJJeT7n8TlMWouzWqSWavFkIhHyIbIAEapg==}
@@ -1321,6 +1376,10 @@ packages:
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
 
+  json5@1.0.2:
+    resolution: {integrity: sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==}
+    hasBin: true
+
   json5@2.2.3:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
     engines: {node: '>=6'}
@@ -1444,6 +1503,9 @@ packages:
     resolution: {integrity: sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==}
     engines: {node: '>=16 || 14 >=14.17'}
 
+  minimist@1.2.8:
+    resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
+
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
@@ -1480,6 +1542,10 @@ packages:
 
   object.fromentries@2.0.8:
     resolution: {integrity: sha512-k6E21FzySsSK5a21KRADBd/NGneRegFO5pLHfdQLpRDETUNJueLXs3WCzyQ3tFRDYgbq3KHGXfTbi2bs8WQ6rQ==}
+    engines: {node: '>= 0.4'}
+
+  object.groupby@1.0.3:
+    resolution: {integrity: sha512-+Lhy3TQTuzXI5hevh8sBGqbmurHbbIjAi0Z4S63nthVLmLxfbj4T54a4CfZrXIrt9iP4mVAPYMo/v99taj3wjQ==}
     engines: {node: '>= 0.4'}
 
   object.values@1.2.1:
@@ -1591,6 +1657,11 @@ packages:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
     engines: {node: '>=4'}
 
+  resolve@1.22.10:
+    resolution: {integrity: sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==}
+    engines: {node: '>= 0.4'}
+    hasBin: true
+
   resolve@2.0.0-next.5:
     resolution: {integrity: sha512-U7WjGVG9sH8tvjW5SmGbQuui75FiyjAX72HX15DwBBwF9dNiQZRQAg9nnPhYy+TUnE0+VcrttuvNI8oSxZcocA==}
     hasBin: true
@@ -1699,6 +1770,10 @@ packages:
     resolution: {integrity: sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==}
     engines: {node: '>= 0.4'}
 
+  strip-bom@3.0.0:
+    resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
+    engines: {node: '>=4'}
+
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
@@ -1738,6 +1813,9 @@ packages:
     engines: {node: '>=18.12'}
     peerDependencies:
       typescript: '>=4.8.4'
+
+  tsconfig-paths@3.15.0:
+    resolution: {integrity: sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg==}
 
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
@@ -2240,6 +2318,8 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.39.0':
     optional: true
 
+  '@rtsao/scc@1.1.0': {}
+
   '@tauri-apps/api@2.4.1': {}
 
   '@tauri-apps/cli-darwin-arm64@2.4.1':
@@ -2344,6 +2424,8 @@ snapshots:
   '@types/estree@1.0.7': {}
 
   '@types/json-schema@7.0.15': {}
+
+  '@types/json5@0.0.29': {}
 
   '@types/prop-types@15.7.14': {}
 
@@ -2534,6 +2616,16 @@ snapshots:
       es-object-atoms: 1.1.1
       es-shim-unscopables: 1.1.0
 
+  array.prototype.findlastindex@1.2.6:
+    dependencies:
+      call-bind: 1.0.8
+      call-bound: 1.0.4
+      define-properties: 1.2.1
+      es-abstract: 1.23.9
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.1
+      es-shim-unscopables: 1.1.0
+
   array.prototype.flat@1.3.3:
     dependencies:
       call-bind: 1.0.8
@@ -2669,6 +2761,10 @@ snapshots:
       call-bound: 1.0.4
       es-errors: 1.3.0
       is-data-view: 1.0.2
+
+  debug@3.2.7:
+    dependencies:
+      ms: 2.1.3
 
   debug@4.4.0:
     dependencies:
@@ -2840,6 +2936,53 @@ snapshots:
   escalade@3.2.0: {}
 
   escape-string-regexp@4.0.0: {}
+
+  eslint-import-resolver-node@0.3.9:
+    dependencies:
+      debug: 3.2.7
+      is-core-module: 2.16.1
+      resolve: 1.22.10
+    transitivePeerDependencies:
+      - supports-color
+
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.29.1(eslint@9.24.0(jiti@2.4.2))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint@9.24.0(jiti@2.4.2)):
+    dependencies:
+      debug: 3.2.7
+    optionalDependencies:
+      '@typescript-eslint/parser': 8.29.1(eslint@9.24.0(jiti@2.4.2))(typescript@5.6.3)
+      eslint: 9.24.0(jiti@2.4.2)
+      eslint-import-resolver-node: 0.3.9
+    transitivePeerDependencies:
+      - supports-color
+
+  eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.29.1(eslint@9.24.0(jiti@2.4.2))(typescript@5.6.3))(eslint@9.24.0(jiti@2.4.2)):
+    dependencies:
+      '@rtsao/scc': 1.1.0
+      array-includes: 3.1.8
+      array.prototype.findlastindex: 1.2.6
+      array.prototype.flat: 1.3.3
+      array.prototype.flatmap: 1.3.3
+      debug: 3.2.7
+      doctrine: 2.1.0
+      eslint: 9.24.0(jiti@2.4.2)
+      eslint-import-resolver-node: 0.3.9
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.29.1(eslint@9.24.0(jiti@2.4.2))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint@9.24.0(jiti@2.4.2))
+      hasown: 2.0.2
+      is-core-module: 2.16.1
+      is-glob: 4.0.3
+      minimatch: 3.1.2
+      object.fromentries: 2.0.8
+      object.groupby: 1.0.3
+      object.values: 1.2.1
+      semver: 6.3.1
+      string.prototype.trimend: 1.0.9
+      tsconfig-paths: 3.15.0
+    optionalDependencies:
+      '@typescript-eslint/parser': 8.29.1(eslint@9.24.0(jiti@2.4.2))(typescript@5.6.3)
+    transitivePeerDependencies:
+      - eslint-import-resolver-typescript
+      - eslint-import-resolver-webpack
+      - supports-color
 
   eslint-plugin-react-hooks@5.2.0(eslint@9.24.0(jiti@2.4.2)):
     dependencies:
@@ -3228,6 +3371,10 @@ snapshots:
 
   json-stable-stringify-without-jsonify@1.0.1: {}
 
+  json5@1.0.2:
+    dependencies:
+      minimist: 1.2.8
+
   json5@2.2.3: {}
 
   jsx-ast-utils@3.3.5:
@@ -3331,6 +3478,8 @@ snapshots:
     dependencies:
       brace-expansion: 2.0.1
 
+  minimist@1.2.8: {}
+
   ms@2.1.3: {}
 
   nanoid@3.3.11: {}
@@ -3367,6 +3516,12 @@ snapshots:
       define-properties: 1.2.1
       es-abstract: 1.23.9
       es-object-atoms: 1.1.1
+
+  object.groupby@1.0.3:
+    dependencies:
+      call-bind: 1.0.8
+      define-properties: 1.2.1
+      es-abstract: 1.23.9
 
   object.values@1.2.1:
     dependencies:
@@ -3481,6 +3636,12 @@ snapshots:
       set-function-name: 2.0.2
 
   resolve-from@4.0.0: {}
+
+  resolve@1.22.10:
+    dependencies:
+      is-core-module: 2.16.1
+      path-parse: 1.0.7
+      supports-preserve-symlinks-flag: 1.0.0
 
   resolve@2.0.0-next.5:
     dependencies:
@@ -3655,6 +3816,8 @@ snapshots:
       define-properties: 1.2.1
       es-object-atoms: 1.1.1
 
+  strip-bom@3.0.0: {}
+
   strip-json-comments@3.1.1: {}
 
   supports-color@7.2.0:
@@ -3680,6 +3843,13 @@ snapshots:
   ts-api-utils@2.1.0(typescript@5.6.3):
     dependencies:
       typescript: 5.6.3
+
+  tsconfig-paths@3.15.0:
+    dependencies:
+      '@types/json5': 0.0.29
+      json5: 1.0.2
+      minimist: 1.2.8
+      strip-bom: 3.0.0
 
   type-check@0.4.0:
     dependencies:

--- a/src/atoms/app.ts
+++ b/src/atoms/app.ts
@@ -1,16 +1,16 @@
 import { atom } from "jotai";
-import { ViewImageMode } from "../types/image";
 import { AppViewMode } from "../types/app";
-import {
-  isFirstPageAtom as isZipFirstPageAtom,
-  isLastPageAtom as isZipLastPageAtom,
-  isOpenZipAtom,
-} from "./zip";
+import { ViewImageMode } from "../types/image";
 import {
   isFirstPageAtom as isImageFirstPageAtom,
   isLastPageAtom as isImageLastPageAtom,
   isOpenImageAtom,
 } from "./image";
+import {
+  isFirstPageAtom as isZipFirstPageAtom,
+  isLastPageAtom as isZipLastPageAtom,
+  isOpenZipAtom,
+} from "./zip";
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
 アプリケーション全体の状態を管理する atom を集めたファイル

--- a/src/atoms/config.ts
+++ b/src/atoms/config.ts
@@ -1,8 +1,8 @@
+import { PhysicalPosition, PhysicalSize } from "@tauri-apps/api/dpi";
+import { getCurrentWindow } from "@tauri-apps/api/window";
 import { atom } from "jotai";
 import { WindowConfig, KeyboardConfig } from "../types/config";
 import { AppEvent } from "../types/event";
-import { PhysicalPosition, PhysicalSize } from "@tauri-apps/api/dpi";
-import { getCurrentWindow } from "@tauri-apps/api/window";
 
 /**
  * 右開きでのデフォルトのキーボード操作

--- a/src/atoms/event.ts
+++ b/src/atoms/event.ts
@@ -1,4 +1,7 @@
 import { atom } from "jotai";
+import { KeyboardConfig } from "../types/config";
+import { AppEvent } from "../types/event";
+import { getHorizontalSwitchEvent } from "../utils/event";
 import {
   isOpeningRenameViewAtom,
   isMagnifierEnabledAtom,
@@ -6,11 +9,8 @@ import {
   pageDirectionAtom,
 } from "./app";
 import { keyboardConfigAtom } from "./config";
-import { handleAppEvent as handleEventZip } from "./zip";
 import { handleAppEvent as handleEventImage } from "./image";
-import { AppEvent } from "../types/event";
-import { KeyboardConfig } from "../types/config";
-import { getHorizontalSwitchEvent } from "../utils/event";
+import { handleAppEvent as handleEventZip } from "./zip";
 
 /**
  * イベントを処理する atom

--- a/src/atoms/image.ts
+++ b/src/atoms/image.ts
@@ -1,4 +1,7 @@
+import { getCurrentWindow } from "@tauri-apps/api/window";
 import { atom } from "jotai";
+import { AppEvent } from "../types/event";
+import { dirFromPath, getFileList } from "../utils/files";
 import { getImageOrientation } from "../utils/utils";
 import {
   appModeAtom,
@@ -7,9 +10,6 @@ import {
   stopSlideshowAtom,
   viewingImageAtom,
 } from "./app";
-import { AppEvent } from "../types/event";
-import { dirFromPath, getFileList } from "../utils/files";
-import { getCurrentWindow } from "@tauri-apps/api/window";
 
 // 画像ファイルを開いたときの状態を管理する
 

--- a/src/atoms/zip.test.ts
+++ b/src/atoms/zip.test.ts
@@ -1,4 +1,5 @@
 import { createStore } from "jotai";
+import { viewingImageAtom } from "./app";
 import {
   $imageNameListAtom,
   moveFirstImageAtom,
@@ -13,7 +14,6 @@ import {
   movePrevPageAtom,
   movePrevSingleImageAtom,
 } from "./zip";
-import { viewingImageAtom } from "./app";
 
 afterEach(() => {
   vi.clearAllMocks();

--- a/src/atoms/zip.ts
+++ b/src/atoms/zip.ts
@@ -1,8 +1,17 @@
-import { atom } from "jotai";
-import * as fflate from "fflate";
 import { convertFileSrc } from "@tauri-apps/api/core";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import { rename, exists } from "@tauri-apps/plugin-fs";
+import * as fflate from "fflate";
+import { atom } from "jotai";
+import { ZipData } from "../types/data";
+import { AppEvent } from "../types/event";
+import {
+  getFileNameRemovedExtension,
+  getFileList,
+  createRenamedPathToExcludeExtensionName,
+  createExclamationAddedPath,
+} from "../utils/files";
+import { getImageOrientation, searchAtBrowser } from "../utils/utils";
 import {
   appModeAtom,
   isOpeningRenameViewAtom,
@@ -11,15 +20,6 @@ import {
   stopSlideshowAtom,
   viewingImageAtom,
 } from "./app";
-import { getImageOrientation, searchAtBrowser } from "../utils/utils";
-import { AppEvent } from "../types/event";
-import { ZipData } from "../types/data";
-import {
-  getFileNameRemovedExtension,
-  getFileList,
-  createRenamedPathToExcludeExtensionName,
-  createExclamationAddedPath,
-} from "../utils/files";
 
 type LastIndex = {
   path: string;

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1,13 +1,7 @@
-import { CSSProperties, useCallback, useEffect } from "react";
-import { useAtom, useAtomValue, useSetAtom } from "jotai";
 import { listen } from "@tauri-apps/api/event";
 import { CheckMenuItem, Menu, MenuItem, PredefinedMenuItem, Submenu } from "@tauri-apps/api/menu";
-import { Log } from "./Log";
-import { openZipAtom } from "../atoms/zip";
-import { useRestoreWindowConfig, useStoreWindowConfig, useWindowEvent } from "../hooks/config";
-import { ImageView } from "./ImageView";
-import { Indicator } from "./Indicator";
-import { RenameBox } from "./RenameBox";
+import { useAtom, useAtomValue, useSetAtom } from "jotai";
+import { CSSProperties, useCallback, useEffect } from "react";
 import {
   canMoveNextAtom,
   canMovePrevAtom,
@@ -15,11 +9,17 @@ import {
   isOpenPageAtom,
   singleOrDoubleAtom,
 } from "../atoms/app";
-import { TopMenu } from "./TopMenu";
-import { getPathKind } from "../utils/files";
-import { openImagePathAtom } from "../atoms/image";
-import { AppEvent } from "../types/event";
 import { handleEventAtom } from "../atoms/event";
+import { openImagePathAtom } from "../atoms/image";
+import { openZipAtom } from "../atoms/zip";
+import { useRestoreWindowConfig, useStoreWindowConfig, useWindowEvent } from "../hooks/config";
+import { AppEvent } from "../types/event";
+import { getPathKind } from "../utils/files";
+import { ImageView } from "./ImageView";
+import { Indicator } from "./Indicator";
+import { Log } from "./Log";
+import { RenameBox } from "./RenameBox";
+import { TopMenu } from "./TopMenu";
 
 const APP_STYLE: CSSProperties = {
   height: "100dvh",

--- a/src/components/ImageView.tsx
+++ b/src/components/ImageView.tsx
@@ -1,15 +1,15 @@
-import { CSSProperties } from "react";
+import { Menu } from "@tauri-apps/api/menu";
 import { useAtomValue, useSetAtom } from "jotai";
+import { CSSProperties } from "react";
 import {
   canMoveNextAtom,
   canMovePrevAtom,
   pageDirectionAtom,
   viewingImageAtom,
 } from "../atoms/app";
-import { SingleImageView } from "./SingleImageView";
-import { Menu } from "@tauri-apps/api/menu";
-import { AppEvent } from "../types/event";
 import { handleEventAtom } from "../atoms/event";
+import { AppEvent } from "../types/event";
+import { SingleImageView } from "./SingleImageView";
 
 /**
  * 画像を表示するコンポーネント

--- a/src/components/Indicator.tsx
+++ b/src/components/Indicator.tsx
@@ -1,7 +1,7 @@
-import React, { useCallback, useEffect, useRef, useState } from "react";
 import { useAtomValue } from "jotai";
-import { useImageData } from "../hooks/images";
+import React, { useCallback, useEffect, useRef, useState } from "react";
 import { pageDirectionAtom } from "../atoms/app";
+import { useImageData } from "../hooks/images";
 
 /** コンポーネント全体のラッパーのスタイル */
 const CONTAINER_STYLE: React.CSSProperties = {

--- a/src/components/TopMenu.tsx
+++ b/src/components/TopMenu.tsx
@@ -1,5 +1,5 @@
-import { useState, type CSSProperties } from "react";
 import { useAtom, useAtomValue, useSetAtom } from "jotai";
+import { useState, type CSSProperties } from "react";
 import {
   isSlideshowRunningAtom,
   pageDirectionAtom,
@@ -7,9 +7,9 @@ import {
   slideshowIntervalAtom,
   viewingImageAtom,
 } from "../atoms/app";
+import { handleEventAtom } from "../atoms/event";
 import { useSlideshow } from "../hooks/event";
 import { AppEvent } from "../types/event";
-import { handleEventAtom } from "../atoms/event";
 
 /**
  * 画面上部に表示する挙動切替メニューのコンポーネント

--- a/src/hooks/config.ts
+++ b/src/hooks/config.ts
@@ -2,8 +2,8 @@ import { getCurrentWindow, LogicalPosition, LogicalSize } from "@tauri-apps/api/
 import { useAtom } from "jotai";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { windowConfigDataAtom, windowPositionAtom, windowSizeAtom } from "../atoms/config";
-import { readConfigFile, storeConfigFile } from "../utils/utils";
 import { WINDOW_CONFIG_FILE_NAME } from "../types/config";
+import { readConfigFile, storeConfigFile } from "../utils/utils";
 
 /**
  * ウィンドウ操作のイベント（移動とリサイズ）を扱う関数を返すカスタムフック

--- a/src/hooks/event.ts
+++ b/src/hooks/event.ts
@@ -1,6 +1,5 @@
-import { useCallback, useEffect } from "react";
 import { useAtom, useAtomValue, useSetAtom } from "jotai";
-import { AppEvent } from "../types/event";
+import { useCallback, useEffect } from "react";
 import {
   resetSlideshowAtom,
   slideshowCountAtom,
@@ -9,6 +8,7 @@ import {
   stopSlideshowAtom,
 } from "../atoms/app";
 import { handleEventAtom } from "../atoms/event";
+import { AppEvent } from "../types/event";
 
 // =  =  =  =  =  =  =  =  =  =  =  =  =  =  =  =  =  =  =  =  =  =  =  =  =  =  =  =  =  =  =  =
 // #region スライドショー関連

--- a/src/hooks/images.ts
+++ b/src/hooks/images.ts
@@ -1,15 +1,15 @@
 import { useAtomValue, useSetAtom } from "jotai";
-import {
-  imageListAtom as zipListAtom,
-  openingImageIndexAtom as zipIndexAtom,
-  moveIndexAtom as zipMoveIndexAtom,
-} from "../atoms/zip";
 import { appModeAtom } from "../atoms/app";
 import {
   openingImageIndexAtom as imageIndexAtom,
   imageListAtom,
   moveIndexAtom as imageMoveIndexAtom,
 } from "../atoms/image";
+import {
+  imageListAtom as zipListAtom,
+  openingImageIndexAtom as zipIndexAtom,
+  moveIndexAtom as zipMoveIndexAtom,
+} from "../atoms/zip";
 
 /**
  * 表示画像に関する情報を扱うカスタムフック

--- a/src/utils/hooks.ts
+++ b/src/utils/hooks.ts
@@ -1,5 +1,5 @@
-import { useEffect, useState } from "react";
 import { convertFileSrc } from "@tauri-apps/api/core";
+import { useEffect, useState } from "react";
 import type { ImageSize, ImageOrientation } from "../types/image";
 
 /**

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1,8 +1,8 @@
 import { convertFileSrc } from "@tauri-apps/api/core";
-import { WindowConfig } from "../types/config";
 import { appConfigDir, join } from "@tauri-apps/api/path";
 import { exists, mkdir, open, readTextFile } from "@tauri-apps/plugin-fs";
 import { openUrl } from "@tauri-apps/plugin-opener";
+import { WindowConfig } from "../types/config";
 import type { ImageOrientation } from "../types/image";
 
 // = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,6 @@
 /// <reference types="vitest" />
-import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
+import { defineConfig } from "vite";
 
 // @ts-expect-error process is a nodejs global
 const host = process.env.TAURI_DEV_HOST;


### PR DESCRIPTION
import 順が適当だったので、eslint ルールを導入して自動的に制御する。

以下のコマンドにより導入。

```sh
pnpm add -D eslint-plugin-import
```

`eslint.config.js` のルールを設定して、以下のコマンドで自動適用。

```sh
pnpx eslint --fix
```
