### PR TITLE
chore: 型の import に type を付ける eslint ルールを追加

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -21,6 +21,7 @@ export default [
       "react/react-in-jsx-scope": "off",
       "react/jsx-uses-react": "off",
       ...reactHooks.configs.recommended.rules,
+      "@typescript-eslint/consistent-type-imports": ["error", { fixStyle: "inline-type-imports" }],
     },
   },
   {

--- a/src/atoms/app.ts
+++ b/src/atoms/app.ts
@@ -1,6 +1,6 @@
 import { atom } from "jotai";
 import { AppViewMode } from "../types/app";
-import { ViewImageMode } from "../types/image";
+import { type ViewImageMode } from "../types/image";
 import {
   isFirstPageAtom as isImageFirstPageAtom,
   isLastPageAtom as isImageLastPageAtom,

--- a/src/atoms/config.ts
+++ b/src/atoms/config.ts
@@ -1,7 +1,7 @@
 import { PhysicalPosition, PhysicalSize } from "@tauri-apps/api/dpi";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import { atom } from "jotai";
-import { WindowConfig, KeyboardConfig } from "../types/config";
+import { type WindowConfig, type KeyboardConfig } from "../types/config";
 import { AppEvent } from "../types/event";
 
 /**

--- a/src/atoms/event.ts
+++ b/src/atoms/event.ts
@@ -1,5 +1,5 @@
 import { atom } from "jotai";
-import { KeyboardConfig } from "../types/config";
+import { type KeyboardConfig } from "../types/config";
 import { AppEvent } from "../types/event";
 import { getHorizontalSwitchEvent } from "../utils/event";
 import {

--- a/src/atoms/zip.ts
+++ b/src/atoms/zip.ts
@@ -3,7 +3,7 @@ import { getCurrentWindow } from "@tauri-apps/api/window";
 import { rename, exists } from "@tauri-apps/plugin-fs";
 import * as fflate from "fflate";
 import { atom } from "jotai";
-import { ZipData } from "../types/data";
+import { type ZipData } from "../types/data";
 import { AppEvent } from "../types/event";
 import {
   getFileNameRemovedExtension,

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1,7 +1,7 @@
 import { listen } from "@tauri-apps/api/event";
 import { CheckMenuItem, Menu, MenuItem, PredefinedMenuItem, Submenu } from "@tauri-apps/api/menu";
 import { useAtom, useAtomValue, useSetAtom } from "jotai";
-import { CSSProperties, useCallback, useEffect } from "react";
+import { type CSSProperties, useCallback, useEffect } from "react";
 import {
   canMoveNextAtom,
   canMovePrevAtom,

--- a/src/components/ImageView.tsx
+++ b/src/components/ImageView.tsx
@@ -1,6 +1,6 @@
 import { Menu } from "@tauri-apps/api/menu";
 import { useAtomValue, useSetAtom } from "jotai";
-import { CSSProperties } from "react";
+import { type CSSProperties } from "react";
 import {
   canMoveNextAtom,
   canMovePrevAtom,

--- a/src/components/RenameBox.tsx
+++ b/src/components/RenameBox.tsx
@@ -1,5 +1,5 @@
 import { useAtomValue, useSetAtom } from "jotai";
-import { CSSProperties, useEffect, useRef, useState } from "react";
+import { type CSSProperties, useEffect, useRef, useState } from "react";
 import { isOpeningRenameViewAtom } from "../atoms/app";
 import {
   handleAppEvent,

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -1,4 +1,4 @@
-import { AppEvent } from "./event";
+import { type AppEvent } from "./event";
 
 /**
  * ウィンドウの位置と保存する設定ファイルのファイル名

--- a/src/utils/files.test.ts
+++ b/src/utils/files.test.ts
@@ -1,4 +1,4 @@
-import { exists, FileInfo, lstat, stat } from "@tauri-apps/plugin-fs";
+import { exists, type FileInfo, lstat, stat } from "@tauri-apps/plugin-fs";
 import {
   createExclamationAddedPath,
   createRenamedPathToExcludeExtensionName,

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -2,7 +2,7 @@ import { convertFileSrc } from "@tauri-apps/api/core";
 import { appConfigDir, join } from "@tauri-apps/api/path";
 import { exists, mkdir, open, readTextFile } from "@tauri-apps/plugin-fs";
 import { openUrl } from "@tauri-apps/plugin-opener";
-import { WindowConfig } from "../types/config";
+import { type WindowConfig } from "../types/config";
 import type { ImageOrientation } from "../types/image";
 
 // = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =


### PR DESCRIPTION
型を import する際には type を付けるのが望ましいため、強制する eslint のルールを追加する。

