### PR TITLE
feat: 画像をドラッグ不可 + カーソルのスタイルを固定

### DIFF
--- a/src/components/SingleImageView.tsx
+++ b/src/components/SingleImageView.tsx
@@ -133,7 +133,12 @@ export function SingleImageView({ source, isHalf, justify }: Props) {
 }
 
 /** 1枚の画像 img のスタイル */
-const IMAGE_STYLE: React.CSSProperties = { height: "100%", maxWidth: "100%", objectFit: "contain" };
+const IMAGE_STYLE: React.CSSProperties = {
+  height: "100%",
+  maxWidth: "100%",
+  objectFit: "contain",
+  cursor: "default",
+};
 
 /** 表示画像のコンテナーのスタイル */
 const CONTAINER_STYLE: React.CSSProperties = {

--- a/src/components/SingleImageView.tsx
+++ b/src/components/SingleImageView.tsx
@@ -106,6 +106,7 @@ export function SingleImageView({ source, isHalf, justify }: Props) {
         onMouseEnter={(e) => mouseEnter(e)}
         onMouseLeave={(e) => mouseLeave(e)}
         onMouseMove={(e) => mouseMove(e)}
+        onDragStart={(e) => e.preventDefault()}
       />
       <div
         style={{


### PR DESCRIPTION
表示した画像をドラッグ不可にするとともに、カーソルのスタイルを固定する。

## モチベーション

### 画像をドラッグ不可に変更

表示される画像はブラウザの `img` 要素であるため、ドラッグ可能であり、ローカルにドロップすると保存できるなどの挙動がある。しかしこの挙動は特に意味がなく、また繰り返しドラッグしていると変な表示になる（表示アイコンがどんどん大きくなっていく）ことがあるため、ドラッグできないようにする。

### カーソルのスタイルを固定

元々、カーソルはデフォルトで良いため、特に設定していなかった。

しかしながら Tauri が macOS で使用する Safari の [Live Text](https://support.apple.com/en-my/guide/safari/ibrw20183ad7/mac) というおせっかい機能により、画像に対してテキストが勝手に埋め込まれ、それに伴ってカーソルが `text` (テキスト選択) になってしまうケースがあるため、明示的に `default` を指定する。
