### PR TITLE
feat: 編集メニューを追加

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -213,6 +213,37 @@ function useAppMenu() {
       ],
     });
 
+    const edit = await Submenu.new({
+      text: "編集",
+      items: [
+        await PredefinedMenuItem.new({
+          text: "元に戻す",
+          item: "Undo",
+        }),
+        await PredefinedMenuItem.new({
+          text: "やり直し",
+          item: "Redo",
+        }),
+        separator,
+        await PredefinedMenuItem.new({
+          text: "切り取り",
+          item: "Cut",
+        }),
+        await PredefinedMenuItem.new({
+          text: "コピー",
+          item: "Copy",
+        }),
+        await PredefinedMenuItem.new({
+          text: "貼り付け",
+          item: "Paste",
+        }),
+        await PredefinedMenuItem.new({
+          text: "すべて選択",
+          item: "SelectAll",
+        }),
+      ],
+    });
+
     const view = await Submenu.new({
       text: "表示",
       items: [
@@ -307,7 +338,7 @@ function useAppMenu() {
     });
 
     const menu = await Menu.new({
-      items: [app, file, view, move, window],
+      items: [app, file, edit, view, move, window],
     });
 
     await menu.setAsAppMenu();


### PR DESCRIPTION
メニューに「編集」を追加する。
﻿
<img width="206" alt="image" src="https://github.com/user-attachments/assets/bb67ea09-7c52-46f9-aa12-ea54f6b4944a" />

## モチベーション

リネームのためにテキスト編集を行う際に、コピペ等のテキストの編集コマンドが使用できない状態になっていたため、メニューに追加して実行可能とする。

恐らく [v0.0.7](https://github.com/tris5572/magv/releases/tag/v0.0.7) でメニューを追加したときから使用できなくなっていた模様。

## 備考

- Writing Tools 以下を追加していないのに表示されている理由は不明。Tauri の何らかの機能ではあるはず。
- 表示・編集状態におけるメニューアイテムの有効/無効の切替は後ほど対応する。
