### PR TITLE
style: リネームボックスの文字サイズを縮小

### DIFF
--- a/src/components/RenameBox.tsx
+++ b/src/components/RenameBox.tsx
@@ -27,7 +27,7 @@ const RENAME_BOX_STYLE: CSSProperties = {
 /** ファイル名のスタイル */
 const FILE_NAME_STYLE: CSSProperties = {
   paddingLeft: "0.25rem",
-  fontSize: "1.6rem",
+  fontSize: "1.3rem",
 };
 
 /** テキストボックスのスタイル */
@@ -38,7 +38,7 @@ const TEXT_BOX_STYLE: CSSProperties = {
   padding: "0.5rem 0.25rem",
   margin: "0.25rem 0",
   border: "1px solid hsl(180 10% 50%)",
-  fontSize: "1.8rem",
+  fontSize: "1.4rem",
 };
 
 /**


### PR DESCRIPTION
ファイル名の変更を行うリネームボックスの文字のサイズが大きすぎてデザインが崩れていたため、小さくする。
