### PR TITLE
fix: 単体表示時に最後の画像に移動しないケースを修正

### DIFF
--- a/src/atoms/image.ts
+++ b/src/atoms/image.ts
@@ -400,6 +400,12 @@ const moveLastPageAtom = atom(null, async (get, set) => {
   const lastIndex = fileList.length - 1;
   const path1 = fileList[lastIndex - 1]; // 最後の1つ手前
   const path2 = fileList[lastIndex]; // 最後
+  const isSingleMode = get(singleOrDoubleAtom) === "single"; // 単体表示モードかどうか
+
+  if (isSingleMode) {
+    set(moveIndexAtom, { index: lastIndex, forceSingle: true });
+    return;
+  }
 
   const orientation1 = await getImageOrientation(path1);
   const orientation2 = await getImageOrientation(path2);

--- a/src/atoms/zip.ts
+++ b/src/atoms/zip.ts
@@ -639,6 +639,7 @@ export const moveFirstImageAtom = atom(null, async (_, set) => {
 const moveLastImageAtom = atom(null, async (get, set) => {
   const imageList = get($imageNameListAtom);
   const zipData = get($openingZipDataAtom);
+  const isSingleMode = get(singleOrDoubleAtom) === "single"; // 単体表示モードかどうか
 
   if (!zipData) {
     return;
@@ -648,6 +649,12 @@ const moveLastImageAtom = atom(null, async (get, set) => {
   const lastIndex = imageList.length - 1;
   const name1 = imageList[lastIndex - 1];
   const name2 = imageList[lastIndex];
+
+  // 単体表示モードのときは、最後の2枚の縦横に関係なく、一番最後の画像を表示
+  if (isSingleMode) {
+    set(moveIndexAtom, { index: lastIndex, forceSingle: true });
+    return;
+  }
 
   if (!name2) {
     return;


### PR DESCRIPTION
以下の条件をすべて満たしているとき、最後の画像に遷移しないバグがあったため、修正する。

- 単体表示モード
- アーカイブまたはフォルダの最後の2枚の画像が両方とも縦長
- 最後のページを表示するイベントを発行
