### PR TITLE
fix: 1ページだけ戻るときに戻り先の見開き状態を考慮しないように変更

### DIFF
--- a/src/atoms/zip.test.ts
+++ b/src/atoms/zip.test.ts
@@ -485,7 +485,7 @@ describe("movePrevSingleImageAtom", () => {
     });
   });
 
-  test("単体表示から1つ前の縦へ戻るとき、2つ前も縦なら、見開き表示になること", async () => {
+  test("単体表示から1つ前の縦へ戻るとき、2つ前も縦でも、単体表示になること", async () => {
     const store = createStore();
     vi.spyOn($imageNameListAtom, "read").mockReturnValue(["0", "1", "2", "3"]);
     vi.spyOn($openingImageIndexAtom, "read").mockReturnValue(2);
@@ -500,7 +500,7 @@ describe("movePrevSingleImageAtom", () => {
 
     await store.set(movePrevSingleImageAtom);
     expect(moveIndexAtomSpy).toHaveBeenCalledWith(expect.any(Function), expect.any(Function), {
-      index: 0,
+      index: 1,
     });
   });
 

--- a/src/atoms/zip.ts
+++ b/src/atoms/zip.ts
@@ -574,14 +574,7 @@ export const moveNextSingleImageAtom = atom(null, async (get, set) => {
 /**
  * 1枚だけ前の画像へ移動する atom
  *
- * 右開き（右が若い）で挙動を示すと以下の通り。（表示が「|」の中）
- * - |縦 縦0| 縦1 縦2 → 縦 |縦0 縦1| 縦2
- * - |縦 縦0| 縦1 横2 → 縦 |縦0 縦1| 横2
- * - |縦 縦0| 横1 → 縦 縦0 |横1|
- * - |横0| 縦1 縦2 → 横0 |縦1 縦2|
- * - |横0| 縦1 横2 → 横0 |縦1| 横2
- * - |横0| 横1 縦2 → 横0 |横1| 縦2
- * - (最後の画像が縦で1枚のみ表示されているケースは、|縦 縦0| 開始と同じパターン)
+ * 見開き状態等に関係なく、インデックスを1つだけ前に移動する
  *
  * export for testing
  */
@@ -596,29 +589,12 @@ export const movePrevSingleImageAtom = atom(null, async (get, set) => {
 
   const name0 = imageList[index];
   const name1 = imageList[index - 1];
-  const name2 = imageList[index - 2];
 
   if (!name0 || !name1) {
     return;
   }
 
-  await convertData(zipData, name0);
-  await convertData(zipData, name1);
-  await convertData(zipData, name2);
-  set($openingZipDataAtom, zipData);
-
-  // 現在、横画像を表示していて、-1枚目と-2枚目が両方とも縦長のときは、2枚戻って見開き表示する
-  if (
-    zipData[name0].orientation === "landscape" &&
-    name2 &&
-    zipData[name1].orientation === "portrait" &&
-    zipData[name2].orientation === "portrait"
-  ) {
-    set(moveIndexAtom, { index: index - 2 });
-    return;
-  }
-
-  // それ以外のときは、-1枚目のみを基準に表示する (見開き判定は表示処理で実施)
+  // 1枚分だけ前に戻り、見開き判定は表示処理側で実施
   set(moveIndexAtom, { index: index - 1 });
 });
 


### PR DESCRIPTION
1ページのみ戻る `movePrevSingleImageAtom` の実行時、戻り先のページが見開きになるとき（戻り先で縦の画像が2枚連続するとき）、特に単体表示時の挙動がおかしかったため、修正する。

この修正により、見開き表示時の挙動も変わることになるが、変更後の挙動が自然であると言えるため、問題ない。

## 変更前の問題

> [!NOTE]
> 右開き、すなわち縦書きの漫画と同じ方向で示す。したがって戻ると右側のページへ遷移する。

**単体表示**のとき、以下のような2枚分戻る挙動となっていた。

- 【ヨコ】 タテ タテ → ヨコ タテ 【タテ】

これは、**見開き表示**の1枚戻る挙動をそのまま適用していたため。

- 【ヨコ】 タテ タテ → ヨコ 【タテ タテ】

## 変更後の挙動

### 単体表示

- 【ヨコ】 タテ タテ → ヨコ 【タテ】 タテ

### 見開き表示

- 【タテ タテ】 タテ タテ → タテ 【タテ タテ】 タテ
- 【ヨコ】 タテ タテ → ヨコ 【タテ】 タテ　（これが見開き表示から1枚表示に変わる）




