### PR TITLE
fix: テストのエラーに対応するため Wasm を遅延読み込みに変更

### DIFF
--- a/src/utils/archive.ts
+++ b/src/utils/archive.ts
@@ -8,7 +8,7 @@ const IMAGE_FILE_PATTERN = /\.(jpe?g|png|gif|bmp|webp)$/i;
 const ARCHIVE_FILE_PATTERN = /\.(zip|rar)$/i;
 const MACOS_RESOURCE_PATH_PREFIX = "__MACOSX/";
 
-const unrarWasmBinaryPromise = loadWasmBinary(unrarWasmUrl);
+let unrarWasmBinaryPromise: Promise<ArrayBuffer> | undefined;
 
 type ArchiveFormat = "zip" | "rar";
 
@@ -92,7 +92,7 @@ async function extractRarImages(arrayBuffer: ArrayBuffer): Promise<ExtractedArch
   try {
     const extractor = await createExtractorFromData({
       data: arrayBuffer,
-      wasmBinary: await unrarWasmBinaryPromise,
+      wasmBinary: await getUnrarWasmBinary(),
     });
 
     return [...extractor.extract().files]
@@ -114,6 +114,14 @@ async function extractRarImages(arrayBuffer: ArrayBuffer): Promise<ExtractedArch
     const detail = error instanceof Error ? error.message : String(error);
     throw new Error(`RAR 展開に失敗: ${detail}`);
   }
+}
+
+/**
+ * unrar wasm を必要になったタイミングで一度だけ読み込む。
+ */
+function getUnrarWasmBinary(): Promise<ArrayBuffer> {
+  unrarWasmBinaryPromise ??= loadWasmBinary(unrarWasmUrl);
+  return unrarWasmBinaryPromise;
 }
 
 /**


### PR DESCRIPTION
テストの実行時、以下のエラーが発生する状態となっていたため、修正する。

<img width="1121" height="323" alt="Image" src="https://github.com/user-attachments/assets/a2f5ec02-a1a9-4f0c-b409-1b65af90a625" />

原因はトップレベルで Wasm を即時読み込みしていたためであり、これを遅延読み込みに変更することで対応する。
